### PR TITLE
[FIX]Take a copy of the context before update

### DIFF
--- a/account_bank_statement_import/account_bank_statement_import.py
+++ b/account_bank_statement_import/account_bank_statement_import.py
@@ -35,8 +35,7 @@ class account_bank_statement_import(osv.TransientModel):
 
     def import_file(self, cr, uid, ids, context=None):
         """ Process the file chosen in the wizard, create bank statement(s) and go to reconciliation. """
-        if context is None:
-            context = {}
+        context = dict(context or {})
         #set the active_id in the context, so that any extension module could
         #reuse the fields chosen in the wizard if needed (see .QIF for example)
         context.update({'active_id': ids[0]})


### PR DESCRIPTION
If the method `import_file` is called with the new API, the context is a frozendict and the update will raise `NotImplementedError: 'update' not supported on frozendict`
PR on master: https://github.com/odoo/odoo/pull/5798
