### PR TITLE
FIX identify partner by res.partner.bank

### DIFF
--- a/account_bank_statement_import/account_bank_statement_import.py
+++ b/account_bank_statement_import/account_bank_statement_import.py
@@ -220,6 +220,7 @@ class account_bank_statement_import(osv.TransientModel):
                     bank_account_id = False
                     identifying_string = line_vals.get('account_number', False)
                     if identifying_string:
+                        identifying_string = identifying_string.replace(' ', '').replace('-', '')
                         ids = self.pool.get('res.partner.bank').search(cr, uid, [('acc_number', '=', identifying_string)], context=context)
                         if ids:
                             bank_account_id = ids[0]


### PR DESCRIPTION
In account_bank_statement_import/account_bank_statement_import.py line 192, it creates a res.partner.bank with acc_number that has been "cleaned" with "replace(' ', '').replace('-', '')"

But, in the same file line 224, it searches res.partner.bank with identifying_string without doing the same "cleanup", so it doesn't find the res.partner.bank and therefore doesn't set the partner on the bank statement line.

This fix does the same "cleanup" on identifying_string, so that odoo can identify the partner by res.partner.bank.
