### PR TITLE
8.0 FIX 2 variables had the same name (account_number)

### DIFF
--- a/account_bank_statement_import/models/account_bank_statement_import.py
+++ b/account_bank_statement_import/models/account_bank_statement_import.py
@@ -299,16 +299,16 @@ class AccountBankStatementImport(models.TransientModel):
                 # closed.
                 partner_id = False
                 bank_account_id = False
-                account_number = line_vals.get('account_number')
-                if account_number:
+                partner_account_number = line_vals.get('account_number')
+                if partner_account_number:
                     bank_model = self.env['res.partner.bank']
                     banks = bank_model.search(
-                        [('acc_number', '=', account_number)], limit=1)
+                        [('acc_number', '=', partner_account_number)], limit=1)
                     if banks:
                         bank_account_id = banks[0].id
                         partner_id = banks[0].partner_id.id
                     else:
-                        bank_obj = self._create_bank_account(account_number)
+                        bank_obj = self._create_bank_account(partner_account_number)
                         bank_account_id = bank_obj and bank_obj.id or False
                 line_vals['partner_id'] = partner_id
                 line_vals['bank_account_id'] = bank_account_id

--- a/account_bank_statement_import/models/account_bank_statement_import.py
+++ b/account_bank_statement_import/models/account_bank_statement_import.py
@@ -308,7 +308,8 @@ class AccountBankStatementImport(models.TransientModel):
                         bank_account_id = banks[0].id
                         partner_id = banks[0].partner_id.id
                     else:
-                        bank_obj = self._create_bank_account(partner_account_number)
+                        bank_obj = self._create_bank_account(
+                            partner_account_number)
                         bank_account_id = bank_obj and bank_obj.id or False
                 line_vals['partner_id'] = partner_id
                 line_vals['bank_account_id'] = bank_account_id


### PR DESCRIPTION
The same variable name (account_number) is used for 2 different things: in the method() _complete_statement() in account_bank_statement_import/account_bank_statement_import.py:

1) the first 'account_number' variable is the last argument of the method and contains the bank account number of the imported file. In this method, it is used as a prefix in the 'unique_import_id' field, so as to have a stronger 'unique_import_id' that contain the bank account number.
2) the second 'account_number' variable is used in the loop on the bank statement lines and gets the account number of the partner related to this bank statement line.

So the second variable 'account_number' over-write the first one after the first pass in the loop !!!

In the scenario of my customer that found this bug, I was importing an OFX file. The OFX files don't contain any partner account_number on bank statement lines (at least for French banks). So, when I had a look at the unique_import_id of the bank statement lines, I had:
00143525710-201501900006BD27
201501900005BD27
201501900004BD27
201501900003BD27
201501900002BD27
201501900001BD27

The first bank statement line had the bank account number in the unique_import_id, but not the next ones, because of the over-write of the variable account_number. The problem is that the unique_import_id of the other lines (201501900004BD27) were already used by other bank statement lines from other accounts in other companies (this is a multi-company setup)... so the resulting bank statement was almost empty, because most lines had been "dropped" by the import thinking they were duplicates.

This is an important regressing ; it seems that the bug was introduced by Ronald in this commit https://github.com/OCA/bank-statement-import/commit/182ea2893a303c2d306d3abb9588464aabd33d5e on June 22nd 2015.
