### PR TITLE
Port account_bank_statement_import_ofx for 9.0

### DIFF
--- a/account_bank_statement_import_ofx/__openerp__.py
+++ b/account_bank_statement_import_ofx/__openerp__.py
@@ -16,5 +16,5 @@
         'python': ['ofxparse'],
     },
     'auto_install': False,
-    'installable': False,
+    'installable': True,
 }

--- a/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
+++ b/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
@@ -46,7 +46,7 @@ class AccountBankStatementImport(models.TransientModel):
                 # generic module uses to find partner/bank)
                 bank_account_id = partner_id = False
                 banks = self.env['res.partner.bank'].search(
-                    [('owner_name', '=', transaction.payee)], limit=1)
+                    [('bank_name', '=', transaction.payee)], limit=1)
                 if banks:
                     bank_account = banks[0]
                     bank_account_id = bank_account.id


### PR DESCRIPTION
Originally module does not work on odoo 9.0
In order to make it work on 9.0 i removed modified module "account bank_statement_import" because ofx import won`t work with it. It is supposes to use same original module. Besides field "owner_name" now is gone. Its calls now "bank_name", as i assume. 
