### PR TITLE
8.0 Add support for OFX files without <NAME> inside all <STMTTRN>

### DIFF
--- a/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
+++ b/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
@@ -45,12 +45,13 @@ class AccountBankStatementImport(models.TransientModel):
                 # (normal behavious is to provide 'account_number', which the
                 # generic module uses to find partner/bank)
                 bank_account_id = partner_id = False
-                banks = self.env['res.partner.bank'].search(
-                    [('owner_name', '=', transaction.payee)], limit=1)
-                if banks:
-                    bank_account = banks[0]
-                    bank_account_id = bank_account.id
-                    partner_id = bank_account.partner_id.id
+                if transaction.payee:
+                    banks = self.env['res.partner.bank'].search(
+                        [('owner_name', '=', transaction.payee)], limit=1)
+                    if banks:
+                        bank_account = banks[0]
+                        bank_account_id = bank_account.id
+                        partner_id = bank_account.partner_id.id
                 vals_line = {
                     'date': transaction.date,
                     'name': transaction.payee + (

--- a/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
+++ b/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
@@ -61,6 +61,15 @@ class AccountBankStatementImport(models.TransientModel):
                     'bank_account_id': bank_account_id,
                     'partner_id': partner_id,
                 }
+                # Memo (<NAME>) and payee (<PAYEE>) are not required
+                # field in OFX statement, cf section 11.4.3 Statement
+                # Transaction <STMTTRN> of the OFX specs: the required
+                # elements are in bold, cf 1.5 Conventions and these 2
+                # fields are not in bold.
+                # But the 'name' field of account.bank.statement.line is
+                # required=True, so we must always have a value !
+                if not vals_line['name']:
+                    vals_line['name'] = '-'
                 total_amt += float(transaction.amount)
                 transactions.append(vals_line)
         except Exception, e:

--- a/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
+++ b/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
@@ -68,8 +68,11 @@ class AccountBankStatementImport(models.TransientModel):
                 # fields are not in bold.
                 # But the 'name' field of account.bank.statement.line is
                 # required=True, so we must always have a value !
+                # The field TRNTYPE is a required field in OFX
                 if not vals_line['name']:
-                    vals_line['name'] = '-'
+                    vals_line['name'] = transaction.type.capitalize()
+                    if transaction.checknum:
+                        vals_line['name'] += ' %s' % transaction.checknum
                 total_amt += float(transaction.amount)
                 transactions.append(vals_line)
         except Exception, e:


### PR DESCRIPTION
Memo (<NAME>) and payee (<PAYEE>) are not required fields in OFX statement, cf section 11.4.3 Statement Transaction <STMTTRN> of the OFX specs: the required elements are in bold, cf 1.5 Conventions and these 2 fields are not in bold. But the 'name' field of account.bank.statement.line is
required=True (cf https://github.com/odoo/odoo/blob/8.0/addons/account/account_bank_statement.py#L930), so I write '-' if it's empty.
