### PR TITLE
OFX: stronger unique_import_id

### DIFF
--- a/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
+++ b/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
@@ -58,7 +58,8 @@ class AccountBankStatementImport(models.TransientModel):
                         transaction.memo and ': ' + transaction.memo or ''),
                     'ref': transaction.id,
                     'amount': transaction.amount,
-                    'unique_import_id': transaction.id,
+                    'unique_import_id': '%s-%s-%s' % (
+                        transaction.id, transaction.payee, transaction.memo),
                     'bank_account_id': bank_account_id,
                     'partner_id': partner_id,
                 }
@@ -83,7 +84,7 @@ class AccountBankStatementImport(models.TransientModel):
             ))
 
         vals_bank_statement = {
-            'name': ofx.account.routing_number,
+            'name': ofx.account.number,
             'transactions': transactions,
             'balance_start': ofx.account.statement.balance,
             'balance_end_real':

--- a/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
+++ b/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
@@ -84,7 +84,7 @@ class AccountBankStatementImport(models.TransientModel):
             ))
 
         vals_bank_statement = {
-            'name': ofx.account.number,
+            'name': '%s-%s' % (ofx.account.routing_number, ofx.account.number),
             'transactions': transactions,
             'balance_start': ofx.account.statement.balance,
             'balance_end_real':

--- a/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
+++ b/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
@@ -84,7 +84,7 @@ class AccountBankStatementImport(models.TransientModel):
             ))
 
         vals_bank_statement = {
-            'name': '%s-%s' % (ofx.account.routing_number, ofx.account.number),
+            'name': ofx.account.number,
             'transactions': transactions,
             'balance_start': ofx.account.statement.balance,
             'balance_end_real':

--- a/account_bank_statement_import_ofx/tests/test_import_bank_statement.py
+++ b/account_bank_statement_import_ofx/tests/test_import_bank_statement.py
@@ -22,7 +22,7 @@ class TestOfxFile(TransactionCase):
             dict(data_file=ofx_file))
         bank_statement.import_file()
         bank_st_record = self.bank_statement_model.search(
-            [('name', '=', '000000123')])[0]
+            [('name', '=', '000000123-123456')])[0]
         self.assertEquals(bank_st_record.balance_start, 2156.56)
         self.assertEquals(bank_st_record.balance_end_real, 1796.56)
 

--- a/account_bank_statement_import_ofx/tests/test_import_bank_statement.py
+++ b/account_bank_statement_import_ofx/tests/test_import_bank_statement.py
@@ -22,7 +22,7 @@ class TestOfxFile(TransactionCase):
             dict(data_file=ofx_file))
         bank_statement.import_file()
         bank_st_record = self.bank_statement_model.search(
-            [('name', '=', '000000123-123456')])[0]
+            [('name', '=', '123456')])[0]
         self.assertEquals(bank_st_record.balance_start, 2156.56)
         self.assertEquals(bank_st_record.balance_end_real, 1796.56)
 


### PR DESCRIPTION
Stronger unique_import_id (to lower the risk of having 2 identical unique_import_id in the same file.. which is possible with the current code, according to my experience)

Add bank account number in bank statement name, instead of only the bank number (important when you have several bank accounts at the same bank)
