### PR TITLE
[FIX] partner_id set to null if not bank_account on statement importation

### DIFF
--- a/account_bank_statement_import/models/account_bank_statement_import.py
+++ b/account_bank_statement_import/models/account_bank_statement_import.py
@@ -351,8 +351,10 @@ class AccountBankStatementImport(models.TransientModel):
                         bank_obj = self._create_bank_account(
                             partner_account_number)
                         bank_account_id = bank_obj and bank_obj.id or False
-                line_vals['partner_id'] = partner_id
-                line_vals['bank_account_id'] = bank_account_id
+                if partner_id:
+                    line_vals['partner_id'] = partner_id
+                if bank_account_id:
+                    line_vals['bank_account_id'] = bank_account_id
         if 'date' in stmt_vals and 'period_id' not in stmt_vals:
             # if the parser found a date but didn't set a period for this date,
             # do this now


### PR DESCRIPTION
Hi,

If not found bank account on statement vals, partner_id always was being null. I don't know any other statements importation file, that "n43" the typical at Spain, "l10n_es_account_bank_statement_import_n43" addon in Spain's repository. This format never brings the bank account but the vat or the name of the customer, usually yes, without this fix, we are unable to import statements, proposing partners, because always set null in partner_id field if not bank account.

Regards.
