### PR TITLE
[FIX] CAMT Statement id may not be unique over time

### DIFF
--- a/account_bank_statement_import_camt/camt.py
+++ b/account_bank_statement_import_camt/camt.py
@@ -202,6 +202,11 @@ class CamtParser(object):
         if statement['transactions']:
             statement.date = datetime.strptime(
                 statement['transactions'][0].execution_date, "%Y-%m-%d")
+            # Prepend first statement's date to improve id uniqueness factor
+            date = statement.date.strftime('%Y%m%d')
+            if date not in statement.statement_id:
+                statement.statement_id = "%s-%s" % (
+                    date, statement.statement_id)
         return statement
 
     def check_version(self, ns, root):


### PR DESCRIPTION
After happily importing a year's worth of Rabobank (NL) statements, we found that some statements would mysteriously be skipped when importing more statements afterwards. As it turns out, Rabobank statement identifiers are reused every year. This would trigger Odoo's rigorous duplicate dropping. This change adds the statement's date to the identifier, if it is not in there already.
