### PR TITLE
80 bank statement import enforce sequence

### DIFF
--- a/account_bank_statement_import/README.rst
+++ b/account_bank_statement_import/README.rst
@@ -38,6 +38,7 @@ Contributors
 * Alexis de Lattre <alexis@via.ecp.fr>
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Ronald Portier <rportier@therp.nl>
+* Luc De Meyer <luc.demeyer@noviat.com>
 
 Maintainer
 ----------

--- a/account_bank_statement_import/__openerp__.py
+++ b/account_bank_statement_import/__openerp__.py
@@ -2,7 +2,7 @@
 {
     'name': 'Account Bank Statement Import',
     'category': 'Banking addons',
-    'version': '8.0.1.0.2',
+    'version': '8.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'OpenERP SA,'
               'Odoo Community Association (OCA)',
@@ -11,6 +11,7 @@
     'data': [
         'views/account_config_settings.xml',
         'views/account_bank_statement_import_view.xml',
+        'views/account_journal.xml',
     ],
     'demo': [
         'demo/fiscalyear_period.xml',

--- a/account_bank_statement_import/models/__init__.py
+++ b/account_bank_statement_import/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-
 from . import res_partner_bank
+from . import account_bank_statement
 from . import account_bank_statement_import
 from . import account_config_settings
+from . import account_journal

--- a/account_bank_statement_import/models/account_bank_statement.py
+++ b/account_bank_statement_import/models/account_bank_statement.py
@@ -1,25 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Odoo, Open Source Management Solution
-#
-#    Copyright (c) 2009-2016 Noviat nv/sa (www.noviat.com).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# Copyright 2009-2016 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from openerp import api, models
 
 

--- a/account_bank_statement_import/models/account_bank_statement.py
+++ b/account_bank_statement_import/models/account_bank_statement.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2009-2016 Noviat nv/sa (www.noviat.com).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import api, models
+
+
+class AccountBankStatement(models.Model):
+    _inherit = 'account.bank.statement'
+
+    @api.model
+    def create(self, vals):
+        if vals.get('name'):
+            journal = self.env['account.journal'].browse(
+                vals.get('journal_id'))
+            if journal.enforce_sequence:
+                vals['name'] = '/'
+        return super(AccountBankStatement, self).create(vals)

--- a/account_bank_statement_import/models/account_journal.py
+++ b/account_bank_statement_import/models/account_journal.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2009-2016 Noviat nv/sa (www.noviat.com).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class account_journal(models.Model):
+    _inherit = 'account.journal'
+
+    enforce_sequence = fields.Boolean(
+        string="Enforce Sequence",
+        help="If checked, the Journal Sequence will determine "
+             "the statement naming policy even if the name is already "
+             "set manually or by the statement import software.")

--- a/account_bank_statement_import/models/account_journal.py
+++ b/account_bank_statement_import/models/account_journal.py
@@ -1,25 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Odoo, Open Source Management Solution
-#
-#    Copyright (c) 2009-2016 Noviat nv/sa (www.noviat.com).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program. If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# Copyright 2009-2016 Noviat
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from openerp import models, fields
 
 

--- a/account_bank_statement_import/models/res_partner_bank.py
+++ b/account_bank_statement_import/models/res_partner_bank.py
@@ -33,8 +33,6 @@ class ResPartnerBank(models.Model):
     sanitized_acc_number = fields.Char(
         'Sanitized Account Number', size=64, readonly=True,
         compute='_get_sanitized_account_number', store=True, index=True)
-    stmt_import_use_journal_seq = fields.Boolean(
-        )
 
     def _sanitize_account_number(self, acc_number):
         if acc_number:

--- a/account_bank_statement_import/models/res_partner_bank.py
+++ b/account_bank_statement_import/models/res_partner_bank.py
@@ -33,6 +33,8 @@ class ResPartnerBank(models.Model):
     sanitized_acc_number = fields.Char(
         'Sanitized Account Number', size=64, readonly=True,
         compute='_get_sanitized_account_number', store=True, index=True)
+    stmt_import_use_journal_seq = fields.Boolean(
+        )
 
     def _sanitize_account_number(self, acc_number):
         if acc_number:

--- a/account_bank_statement_import/views/account_journal.xml
+++ b/account_bank_statement_import/views/account_journal.xml
@@ -8,7 +8,7 @@
       <field name="inherit_id" ref="account.view_account_journal_form"/>
       <field name="arch" type="xml">
         <field name="sequence_id" position="after">
-          <field name="enforce_sequence"/>
+          <field name="enforce_sequence" attrs="{'invisible': [('type', '!=', 'bank')]}"/>
         </field>
       </field>
     </record>

--- a/account_bank_statement_import/views/account_journal.xml
+++ b/account_bank_statement_import/views/account_journal.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="view_account_journal_form" model="ir.ui.view">
+      <field name="name">account.journal.enforce_sequence</field>
+      <field name="model">account.journal</field>
+      <field name="inherit_id" ref="account.view_account_journal_form"/>
+      <field name="arch" type="xml">
+        <field name="sequence_id" position="after">
+          <field name="enforce_sequence"/>
+        </field>
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
Some banks do not put clean and useful identifiers in their camt statements. 
This PR adds the option to enforce the use of the journal sequence for the statement names.
