### PR TITLE
migrate being called when version is None

### DIFF
--- a/account_bank_statement_import/migrations/8.0.1.0/post-migrate.py
+++ b/account_bank_statement_import/migrations/8.0.1.0/post-migrate.py
@@ -21,6 +21,8 @@
 
 
 def migrate(cr, version):
+    if not version:
+        return
     # if we end up here, we migrate from 7.0's account_banking
     # set transaction ids, taking care to enforce uniqueness
     cr.execute(


### PR DESCRIPTION
Tested the following issue:
https://github.com/OCA/bank-statement-import/issues/52
I made sure account_banking was not installed, and did not appear in ir_module_module of the source database. I ran it through a debugger and found that version was None. Compared this script with other scripts and recalled that it is indeed common to return if version is None.
