### PR TITLE
8.0 camt statement

### DIFF
--- a/account_bank_statement_import_camt/camt.py
+++ b/account_bank_statement_import_camt/camt.py
@@ -200,13 +200,12 @@ class CamtParser(object):
             transaction = statement.create_transaction()
             self.parse_transaction(ns, entry_node, transaction)
         if statement['transactions']:
-            statement.date = datetime.strptime(
-                statement['transactions'][0].execution_date, "%Y-%m-%d")
-            # Prepend first statement's date to improve id uniqueness factor
-            date = statement.date.strftime('%Y%m%d')
-            if date not in statement.statement_id:
+            execution_date = statement['transactions'][0].execution_date
+            statement.date = datetime.strptime(execution_date, "%Y-%m-%d")
+            # Prepend date of first transaction to improve id uniquenes
+            if execution_date not in statement.statement_id:
                 statement.statement_id = "%s-%s" % (
-                    date, statement.statement_id)
+                    execution_date, statement.statement_id)
         return statement
 
     def check_version(self, ns, root):

--- a/account_bank_statement_import_camt/camt.py
+++ b/account_bank_statement_import_camt/camt.py
@@ -202,6 +202,11 @@ class CamtParser(object):
         if statement['transactions']:
             statement.date = datetime.strptime(
                 statement['transactions'][0].execution_date, "%Y-%m-%d")
+            # Prepend first statement's date to improve id uniqueness factor
+            date = statement.date.strftime('%Y%m%d')
+            if date not in statement.statement_id:
+                statement.statement_id = "%s-%s" % (
+                    date, statement.statement_id)
         return statement
 
     def check_version(self, ns, root):

--- a/account_bank_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_bank_statement_import_camt/tests/test_import_bank_statement.py
@@ -37,7 +37,7 @@ class TestImport(TestStatementFile):
         ]
         self._test_statement_import(
             'account_bank_statement_import_camt', 'test-camt053.xml',
-            '1234Test/1',
+            '2014-01-05-1234Test/1',
             local_account='NL77ABNA0574908765',
             start_balance=15568.27, end_balance=15121.12,
             transactions=transactions
@@ -47,6 +47,6 @@ class TestImport(TestStatementFile):
         """Test import of multiple statements from zip file."""
         self._test_statement_import(
             'account_bank_statement_import_camt', 'test-camt053.zip',
-            '1234Test/2',  # Only name of first statement
+            '2014-02-05-1234Test/2',  # Only name of first statement
             local_account='NL77ABNA0574908765',
         )


### PR DESCRIPTION
Need date in statement id for camt, because some banks reuse id's in other years.