### PR TITLE
[FIX] filter out unused fields

### DIFF
--- a/account_bank_statement_import_camt/models/account_bank_statement_import.py
+++ b/account_bank_statement_import_camt/models/account_bank_statement_import.py
@@ -22,11 +22,12 @@ class AccountBankStatementImport(models.TransientModel):
             parser = Parser()
             _logger.debug("Try parsing with camt.")
             line_fields = self.env['account.bank.statement.line']._fields
+            extra_fields = ['account_number']
             currency, account_number, statements = parser.parse(data_file)
             for statement in statements:
                 for transaction in statement.get('transactions', []):
                     for key in transaction.keys():
-                        if key not in line_fields:
+                        if key not in line_fields and key not in extra_fields:
                             transaction.pop(key)
             return currency, account_number, statements
         except ValueError:

--- a/account_bank_statement_import_camt/models/account_bank_statement_import.py
+++ b/account_bank_statement_import_camt/models/account_bank_statement_import.py
@@ -21,7 +21,14 @@ class AccountBankStatementImport(models.TransientModel):
         try:
             parser = Parser()
             _logger.debug("Try parsing with camt.")
-            return parser.parse(data_file)
+            line_fields = self.env['account.bank.statement.line']._fields
+            currency, account_number, statements = parser.parse(data_file)
+            for statement in statements:
+                for transaction in statement.get('transactions', []):
+                    for key in transaction:
+                        if key not in line_fields:
+                            transaction.pop(key)
+            return currency, account_number, statements
         except ValueError:
             try:
                 with zipfile.ZipFile(StringIO.StringIO(data_file)) as data:

--- a/account_bank_statement_import_camt/models/account_bank_statement_import.py
+++ b/account_bank_statement_import_camt/models/account_bank_statement_import.py
@@ -25,7 +25,7 @@ class AccountBankStatementImport(models.TransientModel):
             currency, account_number, statements = parser.parse(data_file)
             for statement in statements:
                 for transaction in statement.get('transactions', []):
-                    for key in transaction:
+                    for key in transaction.keys():
                         if key not in line_fields:
                             transaction.pop(key)
             return currency, account_number, statements


### PR DESCRIPTION
The parser returns more fields than statement lines can swallow. I'd like to keep it this way, such that whenever some module add new fields (for example, a type of transaction), it will be filled automagically. But to avoid warnings during tests, we need to filter out the extra fields before passing them super.