### PR TITLE
[10.0] OFX: fix start/end balance

### DIFF
--- a/account_bank_statement_import_ofx/tests/test_import_bank_statement.py
+++ b/account_bank_statement_import_ofx/tests/test_import_bank_statement.py
@@ -38,8 +38,8 @@ class TestOfxFile(TransactionCase):
         bank_statement.import_file()
         bank_st_record = self.abs_model.search(
             [('name', 'like', '123456')])[0]
-        self.assertEquals(bank_st_record.balance_start, 2156.56)
-        self.assertEquals(bank_st_record.balance_end_real, 1796.56)
+        self.assertEquals(bank_st_record.balance_start, 2516.56)
+        self.assertEquals(bank_st_record.balance_end_real, 2156.56)
 
         line = self.absl_model.search([
             ('name', '=', 'Agrolait'),

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -3,7 +3,7 @@
 import logging
 import StringIO
 
-from odoo import api, models, fields, _
+from odoo import api, models, _
 from odoo.exceptions import UserError
 from odoo.tools import float_is_zero
 

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -65,30 +65,23 @@ class AccountBankStatementImport(models.TransientModel):
 
         transactions = []
         total_amt = 0.00
-        start_date = end_date = False
         try:
             for transaction in ofx.account.statement.transactions:
                 vals = self._prepare_ofx_transaction_line(transaction)
                 if vals:
                     transactions.append(vals)
                     total_amt += vals['amount']
-                    tdate = fields.Date.to_string(vals['date'])
-                    if not start_date or tdate < start_date:
-                        start_date = tdate
-                    if not end_date or tdate > end_date:
-                        end_date = tdate
         except Exception, e:
             raise UserError(_(
                 "The following problem occurred during import. "
                 "The file might not be valid.\n\n %s") % e.message)
 
+        balance = float(ofx.account.statement.balance)
         vals_bank_statement = {
-            'name': _('Account %s %s > %s') % (
-                ofx.account.number, start_date, end_date),
+            'name': ofx.account.number,
             'transactions': transactions,
-            'balance_start': ofx.account.statement.balance,
-            'balance_end_real':
-            float(ofx.account.statement.balance) + total_amt,
+            'balance_start': balance - total_amt,
+            'balance_end_real': balance,
         }
         return ofx.account.statement.currency, ofx.account.number, [
             vals_bank_statement]


### PR DESCRIPTION
Remove start/end dates in name of statement, because it's better to have it via 2 computed fields