### PR TITLE
[RFR] Don't unzip xlsx files

### DIFF
--- a/account_bank_statement_import/tests/test_import_file.py
+++ b/account_bank_statement_import/tests/test_import_file.py
@@ -95,6 +95,7 @@ class TestStatementFile(TransactionCase):
         bank_statement_id = import_model.create(
             dict(
                 data_file=statement_file,
+                filename=file_name,
             )
         )
         bank_statement_id.import_file()

--- a/account_bank_statement_import/views/account_bank_statement_import_view.xml
+++ b/account_bank_statement_import/views/account_bank_statement_import_view.xml
@@ -8,7 +8,8 @@
             <field name="priority">1</field>
             <field name="arch" type="xml">
                 <form string="Import Bank Statements">
-                    <field name="data_file"/>
+                    <field name="data_file" filename="filename"/>
+                    <field name="filename" invisible="1"/>
                     <field name="hide_journal_field" invisible="1"/>
                     <label for="journal_id"/>
                     <field name="journal_id"


### PR DESCRIPTION
The 'ask forgiveness' strategy does not work when the import file can actually be unzipped but shouldn't. I'm proposing a slight refactoring that allows overriding customizations to judge by themselves if they want to allow unzipping.