### PR TITLE
[9.0] [ENH] allow camt054 to be parsed

### DIFF
--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -216,10 +216,12 @@ class CamtParser(models.AbstractModel):
         )
         if not re_camt.search(ns):
             raise ValueError('no camt: ' + ns)
-        # Check wether version 052 or 053:
+        # Check wether version 052 ,053 or 054:
         re_camt_version = re.compile(
+            r'(^urn:iso:std:iso:20022:tech:xsd:camt.054.'
             r'(^urn:iso:std:iso:20022:tech:xsd:camt.053.'
             r'|^urn:iso:std:iso:20022:tech:xsd:camt.052.'
+            r'|^ISO:camt.054.'
             r'|^ISO:camt.053.'
             r'|^ISO:camt.052.)'
         )

--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -219,7 +219,7 @@ class CamtParser(models.AbstractModel):
         # Check wether version 052 ,053 or 054:
         re_camt_version = re.compile(
             r'(^urn:iso:std:iso:20022:tech:xsd:camt.054.'
-            r'(^urn:iso:std:iso:20022:tech:xsd:camt.053.'
+            r'|^urn:iso:std:iso:20022:tech:xsd:camt.053.'
             r'|^urn:iso:std:iso:20022:tech:xsd:camt.052.'
             r'|^ISO:camt.054.'
             r'|^ISO:camt.053.'


### PR DESCRIPTION
A small PR to allow camt054 to be parsed. 
camt054 are details of a grouped transaction that occurs in a camt053.
In CH, camt054 are grouped by day inside the camt [therefore the transaction grouping PR ](https://github.com/OCA/bank-statement-import/pull/102)is needed to import the camt054 successfully.
 