### PR TITLE
CAMT import for ING bank Netherlands gives error on saving account lines

### DIFF
--- a/account_bank_statement_import_camt/__openerp__.py
+++ b/account_bank_statement_import_camt/__openerp__.py
@@ -20,6 +20,7 @@
 {
     'name': 'CAMT Format Bank Statements Import',
     'version': '8.0.0.4.0',
+    'summary': 'Module to import SEPA CAMT.053 Format bank statement files',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_camt/camt.py
+++ b/account_bank_statement_import_camt/camt.py
@@ -75,14 +75,19 @@ class CamtParser(object):
         """Parse TxDtls node."""
         # message
         self.add_value_from_node(
-            ns, node, [
+            ns,
+            node,
+            [
                 './ns:RmtInf/ns:Ustrd',
                 './ns:AddtlTxInf',
                 './ns:AddtlNtryInf',
                 './ns:RltdPties/ns:CdtrAcct/ns:Tp/ns:Prtry',
                 './ns:RltdPties/ns:DbtrAcct/ns:Tp/ns:Prtry',
-            ], transaction, 'message', join_str='\n',
-               default=_('No description')
+            ],
+            transaction,
+            'message',
+            join_str='\n',
+            default=_('No description')
         )
         # eref
         self.add_value_from_node(

--- a/account_bank_statement_import_camt/camt.py
+++ b/account_bank_statement_import_camt/camt.py
@@ -21,11 +21,14 @@
 ##############################################################################
 
 import re
+from copy import copy
 from datetime import datetime
 from lxml import etree
+
+from openerp import _
+
 from openerp.addons.account_bank_statement_import.parserlib import (
     BankStatement)
-from copy import copy
 
 
 class CamtParser(object):
@@ -46,7 +49,8 @@ class CamtParser(object):
         return amount
 
     def add_value_from_node(
-            self, ns, node, xpath_str, obj, attr_name, join_str=None):
+            self, ns, node, xpath_str, obj, attr_name, join_str=None,
+            default=None):
         """Add value to object from first or all nodes found with xpath.
 
         If xpath_str is a list (or iterable), it will be seen as a series
@@ -63,6 +67,9 @@ class CamtParser(object):
                     attr_value = join_str.join([x.text for x in found_node])
                 setattr(obj, attr_name, attr_value)
                 break
+        else:
+            if default:
+                setattr(obj, attr_name, default)
 
     def parse_transaction_details(self, ns, node, transaction):
         """Parse TxDtls node."""
@@ -72,7 +79,11 @@ class CamtParser(object):
                 './ns:RmtInf/ns:Ustrd',
                 './ns:AddtlTxInf',
                 './ns:AddtlNtryInf',
-            ], transaction, 'message', join_str='\n')
+                './ns:RltdPties/ns:CdtrAcct/ns:Tp/ns:Prtry',
+                './ns:RltdPties/ns:DbtrAcct/ns:Tp/ns:Prtry',
+            ], transaction, 'message', join_str='\n',
+               default=_('No description')
+        )
         # eref
         self.add_value_from_node(
             ns, node, [


### PR DESCRIPTION
CAMT import for ING bank Netherlands gives error on saving account entries where `Ntry/NtryDtls/TxDtls/RmtInf/Ustrd` element is missing. Selecting `Ntry/NtryDtls/TxDtls/RltdPties/CdtrAcct/Tp/Prtry` in this case, which contains 'Zakelijke spaarrekening' ("Business savings account") in this case. To me that seems clear enough for the transaction name.