### PR TITLE
[10.0][MIG] Allow camt parser inheritance

### DIFF
--- a/account_bank_statement_import_camt/__init__.py
+++ b/account_bank_statement_import_camt/__init__.py
@@ -2,4 +2,3 @@
 # © 2013-2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import models
-from . import camt

--- a/account_bank_statement_import_camt/__manifest__.py
+++ b/account_bank_statement_import_camt/__manifest__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# © 2013-2016 Therp BV <http://therp.nl>
+# © 2013-2017 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'CAMT Format Bank Statements Import',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_camt/models/__init__.py
+++ b/account_bank_statement_import_camt/models/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # © 2013-2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import parser
 from . import account_bank_statement_import

--- a/account_bank_statement_import_camt/models/account_bank_statement_import.py
+++ b/account_bank_statement_import_camt/models/account_bank_statement_import.py
@@ -6,7 +6,6 @@ import logging
 import StringIO
 import zipfile
 from odoo import api, models
-from ..camt import CamtParser as Parser
 
 _logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ class AccountBankStatementImport(models.TransientModel):
     def _parse_file(self, data_file):
         """Parse a CAMT053 XML file."""
         try:
-            parser = Parser()
+            parser = self.env['account.bank.statement.import.camt.parser']
             _logger.debug("Try parsing with camt.")
             return parser.parse(data_file)
         except ValueError:

--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -5,8 +5,11 @@
 import re
 from lxml import etree
 
+from odoo import models
 
-class CamtParser(object):
+
+class CamtParser(models.AbstractModel):
+    _name = 'account.bank.statement.import.camt.parser'
     """Parser for camt bank statement import files."""
 
     def parse_amount(self, ns, node):


### PR DESCRIPTION
Modify camt parser to be an Odoo AbstractModel instead of a pure python object.
This allows inheritance in sub-modules to customize the parser and is needed in Switzerland to extend the functionnalities of the parser.

This is already present in version 9 and should be done as well in version 10.