### PR TITLE
[10.0][IMP] Allow inheritance for CAMT parser to add transaction nodes

### DIFF
--- a/account_bank_statement_import_camt/__manifest__.py
+++ b/account_bank_statement_import_camt/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'CAMT Format Bank Statements Import',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -99,9 +99,10 @@ class CamtParser(models.AbstractModel):
                     'account_number'
                 )
 
-    def parse_entry(self, ns, node):
+    def parse_entry(self, ns, node, transaction=None):
         """Parse an Ntry node and yield transactions"""
-        transaction = {'name': '/', 'amount': 0}  # fallback defaults
+        if transaction is None:
+            transaction = {'name': '/', 'amount': 0}  # fallback defaults
         self.add_value_from_node(
             ns, node, './ns:BookgDt/ns:Dt', transaction, 'date')
         amount = self.parse_amount(ns, node)


### PR DESCRIPTION
This little change allows sub-modules to parse other nodes in a CAMT bank statement and add them to the transaction.