### PR TITLE
[8.0][FIX] account_bank_statement_import_mt940_base. No eref in message.

### DIFF
--- a/account_bank_statement_import_mt940_base/__openerp__.py
+++ b/account_bank_statement_import_mt940_base/__openerp__.py
@@ -1,25 +1,9 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2013-2015 Therp BV <http://therp.nl>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2013-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'MT940 Bank Statements Import',
-    'version': '8.0.1.1.1',
+    'version': '8.0.1.1.2',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_mt940_base/mt940.py
+++ b/account_bank_statement_import_mt940_base/mt940.py
@@ -78,7 +78,12 @@ def get_counterpart(transaction, subfield):
 
 
 def handle_common_subfields(transaction, subfields):
-    """Deal with common functionality for tag 86 subfields."""
+    """Deal with common functionality for tag 86 subfields.
+
+    transaction.eref is filled from 61 record with information on subfield
+    that contains the actual reference in 86 record. So transaction.eref
+    is used for a dual purpose!
+    """
     # Get counterpart from CNTP, BENM or ORDP subfields:
     for counterpart_field in ['CNTP', 'BENM', 'ORDP']:
         if counterpart_field in subfields:
@@ -100,9 +105,8 @@ def handle_common_subfields(transaction, subfields):
             '/'.join(x for x in subfields['REMI'] if x)
         )
     # EREF: End-to-end reference
-    if 'EREF' in subfields:
-        transaction.message += '/'.join(filter(bool, subfields['EREF']))
     # Get transaction reference subfield (might vary):
+    transaction.eref = transaction.eref or 'EREF'
     if transaction.eref in subfields:
         transaction.eref = ''.join(subfields[transaction.eref])
 

--- a/account_bank_statement_import_mt940_base/mt940.py
+++ b/account_bank_statement_import_mt940_base/mt940.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
 """Generic parser for MT940 files, base for customized versions per bank."""
-##############################################################################
-#
-#    Copyright (C) 2014-2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2014-2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import re
 import logging
 from datetime import datetime

--- a/account_bank_statement_import_mt940_base/tests/__init__.py
+++ b/account_bank_statement_import_mt940_base/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_mt940_parser

--- a/account_bank_statement_import_mt940_base/tests/test_mt940_parser.py
+++ b/account_bank_statement_import_mt940_base/tests/test_mt940_parser.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Therp BV <https://therp.nl>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.tests.common import TransactionCase
+
+from openerp.addons.account_bank_statement_import.parserlib import \
+    BankTransaction
+
+from ..mt940 import str2amount, get_subfields, handle_common_subfields
+
+
+RECORD86 = (
+    ":86:/EREF/ZZ12T32FYCIO7YPXC//CNTP/FR7630239881239147035594069/BNP"
+    "AFRPP/JOHN WHO PAID///REMI/USTD//virt AD 934637/")
+CODEWORDS = [
+    'RTRN', 'BENM', 'ORDP', 'CSID', 'BUSP', 'MARF', 'EREF',
+    'PREF', 'REMI', 'ID', 'PURP', 'ULTB', 'ULTD',
+    'CREF', 'IREF', 'CNTP', 'ULTC', 'EXCH', 'CHGS']
+
+
+class TestMT940Parser(TransactionCase):
+    """Test common methods in mt940 parser."""
+
+    def test_str2amount(self):
+        """Test conversion of string to amount."""
+        amount = str2amount('C', '16,16')
+        self.assertEqual(amount, 16.16)
+        amount = str2amount('D', '25,25')
+        self.assertEqual(amount, -25.25)
+
+    def test_get_subfields(self):
+        """Test get subfields."""
+        subfields = get_subfields(RECORD86, CODEWORDS)
+        self.assertIn('EREF', subfields)
+        self.assertEqual('ZZ12T32FYCIO7YPXC', subfields['EREF'][0])
+        self.assertIn('REMI', subfields)
+        self.assertEqual('virt AD 934637', subfields['REMI'][2])
+
+    def test_handle_common_subfields(self):
+        """test handle_common_subfields"""
+        transaction = BankTransaction()
+        subfields = get_subfields(RECORD86, CODEWORDS)
+        handle_common_subfields(transaction, subfields)
+        self.assertEqual('virt AD 934637', transaction.message)
+        self.assertEqual('ZZ12T32FYCIO7YPXC', transaction.eref)


### PR DESCRIPTION
Reference information always goes into (e)ref. Therefore no need to duplicate this info into name.

Made retrieval of reference information a little bit more fool proof.