### PR TITLE
[FIX] `ref` from 10.0 is called `eref` in 8.0

### DIFF
--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -166,7 +166,7 @@ class CamtParser(models.AbstractModel):
                 './ns:NtryDtls/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Ref',
                 './ns:NtryDtls/ns:Btch/ns:PmtInfId',
             ],
-            transaction, 'ref'
+            transaction, 'eref'
         )
         details_nodes = node.xpath(
             './ns:NtryDtls/ns:TxDtls', namespaces={'ns': ns})


### PR DESCRIPTION
when merging #111, we overlooked that `ref` is called `eref` in 8.0