### PR TITLE
FIX QIF errors

### DIFF
--- a/account_bank_statement_import_qif/__manifest__.py
+++ b/account_bank_statement_import_qif/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Import QIF Bank Statements',
     'category': 'Accounting',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'author': 'OpenERP SA,'
               'Tecnativa,'
               'Odoo Community Association (OCA)',

--- a/account_bank_statement_import_qif/wizards/account_bank_statement_import_qif.py
+++ b/account_bank_statement_import_qif/wizards/account_bank_statement_import_qif.py
@@ -35,7 +35,7 @@ class AccountBankStatementImport(models.TransientModel):
         transactions = []
         vals_line = {}
         total = 0
-        if header == "Bank":
+        if header in ("Bank", "CCard"):
             vals_bank_statement = {}
             for line in data_list:
                 line = line.strip()
@@ -58,7 +58,7 @@ class AccountBankStatementImport(models.TransientModel):
                     vals_line['name'] = ('name' in vals_line and
                                          vals_line['name'] + ': ' + line[1:] or
                                          line[1:])
-                elif line[0] == '^':  # end of item
+                elif line[0] == '^' and vals_line:  # end of item
                     transactions.append(vals_line)
                     vals_line = {}
                 elif line[0] == '\n':


### PR DESCRIPTION
Hi,

These 2 fixes allow importing Credit Card Statements and address an ambiguity in the standard as to whether the Header line is followed by an end entry ^.  As a minimum ANZ Bank has the ^ following the Type header.