### PR TITLE
[11.0][IMP] CAMT: allow import of batch

### DIFF
--- a/account_bank_statement_import_camt_oca/README.rst
+++ b/account_bank_statement_import_camt_oca/README.rst
@@ -10,6 +10,20 @@ Module to import SEPA CAMT.053 and CAMT.054 Format bank statement files.
 
 Based on the Banking addons framework.
 
+Configuration
+=============
+
+The user can configure the way CAMT bank statements are imported:
+
+* Go to *Settings* -> *General Settings* -> *Invoicing*
+* Set the *CAMT (OCA) Import Batch* checkbox
+
+If the *CAMT (OCA) Import Batch* checkbox is false, the import will load every single line of the TxDtls details;
+instead if it's true, it will load only the total amount of each batch of lines.
+
+To be able to access the configuration settings, the user must belong to *Show Full Accounting Features* group.
+
+
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
     :alt: Try me on Runbot
     :target: https://runbot.odoo-community.org/runbot/174/11.0

--- a/account_bank_statement_import_camt_oca/__manifest__.py
+++ b/account_bank_statement_import_camt_oca/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'CAMT Format Bank Statements Import',
-    'version': '11.0.1.0.4',
+    'version': '11.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',
@@ -12,5 +12,6 @@
     ],
     'data': [
         'views/account_bank_statement_import.xml',
+        'views/res_config_settings.xml',
     ],
 }

--- a/account_bank_statement_import_camt_oca/models/__init__.py
+++ b/account_bank_statement_import_camt_oca/models/__init__.py
@@ -2,3 +2,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import parser
 from . import account_bank_statement_import
+from . import res_company
+from . import res_config_settings

--- a/account_bank_statement_import_camt_oca/models/parser.py
+++ b/account_bank_statement_import_camt_oca/models/parser.py
@@ -19,13 +19,13 @@ class CamtParser(models.AbstractModel):
         sign = 1
         amount = 0.0
         sign_node = node.xpath('ns:CdtDbtInd', namespaces={'ns': ns})
-        if not sign_node:
+        if not sign_node and not self.env.user.company_id.camt_import_batch:
             sign_node = node.xpath(
                 '../../ns:CdtDbtInd', namespaces={'ns': ns})
         if sign_node and sign_node[0].text == 'DBIT':
             sign = -1
         amount_node = node.xpath('ns:Amt', namespaces={'ns': ns})
-        if not amount_node:
+        if not amount_node and not self.env.user.company_id.camt_import_batch:
             amount_node = node.xpath(
                 './ns:AmtDtls/ns:TxAmt/ns:Amt', namespaces={'ns': ns})
         if amount_node:
@@ -133,6 +133,8 @@ class CamtParser(models.AbstractModel):
             transaction = transaction_base.copy()
             self.parse_transaction_details(ns, node, transaction)
             yield transaction
+            if self.env.user.company_id.camt_import_batch:
+                break
 
     def get_balance_amounts(self, ns, node):
         """Return opening and closing balance.

--- a/account_bank_statement_import_camt_oca/models/res_company.py
+++ b/account_bank_statement_import_camt_oca/models/res_company.py
@@ -1,0 +1,10 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    camt_import_batch = fields.Boolean()

--- a/account_bank_statement_import_camt_oca/models/res_config_settings.py
+++ b/account_bank_statement_import_camt_oca/models/res_config_settings.py
@@ -1,0 +1,10 @@
+# Copyright 2018 Onestein (<http://www.onestein.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    camt_import_batch = fields.Boolean(related='company_id.camt_import_batch')

--- a/account_bank_statement_import_camt_oca/views/res_config_settings.xml
+++ b/account_bank_statement_import_camt_oca/views/res_config_settings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+        <field name="model">res.config.settings</field>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='bank_cash']" position="inside">
+                <div class="col-xs-12 col-md-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="camt_import_batch"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label string="CAMT (OCA) Import Batch"/>
+                        <div class="text-muted">
+                            Import batches of CAMT bank statements (do not import single detailed lines).
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Following the https://github.com/OCA/bank-statement-import/issues/157#issuecomment-411404477 by @thomaspaulb, here is a proposal to allow to skip the loading the TxDtls details. The enabling of this option is configurable.