### PR TITLE
[8.0][IMP] Add option to aggregate batches in CAMT

### DIFF
--- a/account_bank_statement_import/parserlib.py
+++ b/account_bank_statement_import/parserlib.py
@@ -106,6 +106,14 @@ class BankTransaction(dict):
     def note(self, note):
         self['note'] = note
 
+    @property
+    def batch(self):
+        return self.get('batch', False)
+
+    @batch.setter
+    def batch(self, batch):
+        self['batch'] = batch
+
     def __init__(self):
         """Define and initialize attributes.
 

--- a/account_bank_statement_import/tests/test_import_file.py
+++ b/account_bank_statement_import/tests/test_import_file.py
@@ -1,25 +1,8 @@
 # -*- coding: utf-8 -*-
+# Copyright 2015 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 """Provide common base for bank statement import tests."""
-##############################################################################
-#
-#    Copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    All other contributions are (C) by their respective contributors
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+
 import logging
 
 from openerp.tests.common import TransactionCase
@@ -95,11 +78,11 @@ class TestStatementFile(TransactionCase):
         bank_statement_id = import_model.create(
             dict(
                 data_file=statement_file,
-                filename=file_name,
+                filename=file_name
             )
         )
         bank_statement_id.import_file()
-        # Check wether bank account has been created:
+        # Check whether bank account has been created:
         if local_account:
             bids = partner_bank_model.search(
                 [('acc_number', '=', local_account)])

--- a/account_bank_statement_import_camt/README.rst
+++ b/account_bank_statement_import_camt/README.rst
@@ -8,6 +8,20 @@ Module to import SEPA CAMT.053 Format bank statement files.
 
 Based on the Banking addons framework.
 
+Configuration
+=============
+
+The user can configure the way CAMT bank statements are imported:
+
+* Go to *Accounting* -> *Configuration* -> *Journals* -> *Journals*
+* Find the Journal that is related to the bank account you are importing for
+* Set the *Aggregate batch transactions (CAMT)* checkbox
+
+If the checkbox is false, the import will load every single line of the TxDtls details;
+instead if it's true, it will load only the total amount of each batch of lines.
+
+To be able to access the configuration settings, the user must enable Technical features.
+
 Known issues / Roadmap
 ======================
 
@@ -30,6 +44,9 @@ Contributors
 
 * Stefan Rijnhart <srijnhart@therp.nl>
 * Ronald Portier <rportier@therp.nl>
+* Andrea Stirpe <a.stirpe@onestein.nl>
+* Tom Blauwendraat <tom@sunflowerweb.nl>
+* Dan Kiplangat <dan@sunflowerweb.nl>
 
 Maintainer
 ----------

--- a/account_bank_statement_import_camt/__openerp__.py
+++ b/account_bank_statement_import_camt/__openerp__.py
@@ -31,5 +31,8 @@
     'demo': [
         'demo/demo_data.xml',
     ],
+    'data': [
+        'views/account_journal.xml',
+    ],
     'installable': True,
 }

--- a/account_bank_statement_import_camt/i18n/nl.po
+++ b/account_bank_statement_import_camt/i18n/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: bank-statement-import (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-20 16:51+0000\n"
+"POT-Creation-Date: 2018-09-12 10:59+0000\n"
 "PO-Revision-Date: 2018-02-20 16:52+0000\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/oca/OCA-bank-statement-"
@@ -20,9 +20,9 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: account_bank_statement_import_camt
-#: field:account.bank.statement.import.camt.parser,display_name:0
-msgid "Display Name"
-msgstr "Te tonen naam"
+#: field:account.journal,camt_import_batch:0
+msgid "Aggregate batch transactions (CAMT)"
+msgstr "Samenvoegen batch transacties (CAMT)"
 
 #. module: account_bank_statement_import_camt
 #: field:account.bank.statement.import.camt.parser,id:0
@@ -35,12 +35,13 @@ msgid "Import Bank Statement"
 msgstr "Importeer bankafschrift"
 
 #. module: account_bank_statement_import_camt
-#: field:account.bank.statement.import.camt.parser,__last_update:0
-msgid "Last Modified on"
-msgstr "Laatst bijgewerkt op"
+#: model:ir.model,name:account_bank_statement_import_camt.model_account_journal
+msgid "Journal"
+msgstr "Journal"
 
 #. module: account_bank_statement_import_camt
-#: code:addons/account_bank_statement_import_camt/models/parser.py:99
+#: code:addons/account_bank_statement_import_camt/models/parser.py:83
 #, python-format
 msgid "No description"
 msgstr ""
+

--- a/account_bank_statement_import_camt/models/__init__.py
+++ b/account_bank_statement_import_camt/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2013-2016 Therp BV <http://therp.nl>
+# Copyright 2013-2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import parser
 from . import account_bank_statement_import
+from . import account_journal

--- a/account_bank_statement_import_camt/models/account_journal.py
+++ b/account_bank_statement_import_camt/models/account_journal.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013-2016 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    camt_import_batch = fields.Boolean(
+        string='Aggregate batch transactions (CAMT)')

--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -1,24 +1,8 @@
 # -*- coding: utf-8 -*-
+# Copyright 2013-2015 Therp BV <http://therp.nl>
+# Copyright 2017 Open Net Sàrl
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 """Class to parse camt files."""
-##############################################################################
-#
-#    Copyright (C) 2013-2015 Therp BV <http://therp.nl>
-#    Copyright 2017 Open Net Sàrl
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
 
 import re
 from copy import copy
@@ -173,6 +157,12 @@ class CamtParser(models.AbstractModel):
                 './ns:NtryDtls/ns:Btch/ns:PmtInfId',
             ],
             transaction, 'eref'
+        )
+        self.add_value_from_node(
+            ns, node, [
+                './ns:NtryDtls/ns:Btch/ns:MsgId',
+            ],
+            transaction, 'batch'
         )
         details_nodes = node.xpath(
             './ns:NtryDtls/ns:TxDtls', namespaces={'ns': ns})

--- a/account_bank_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_bank_statement_import_camt/tests/test_import_bank_statement.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright 2015 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 """Run test to import camt.053 import."""
-##############################################################################
-#
-#    Copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
 from openerp.addons.account_bank_statement_import.tests import (
     TestStatementFile)
 
@@ -57,6 +41,27 @@ class TestImport(TestStatementFile):
             'account_bank_statement_import_camt', 'test-camt053.xml',
             '2014-01-05-1234Test/1',
             local_account='NL77ABNA0574908765',
+            start_balance=15568.27, end_balance=15121.12,
+            transactions=transactions
+        )
+
+    def test_statement_import_batch(self):
+        """Test aggregate import of batch statement."""
+        transactions = [
+            {
+                # remote bank account will be left empty
+                'transferred_amount': -664.05,
+                'value_date': '2014-01-05',
+                'ref': '2014/125',
+            }
+        ]
+        bank = self.env.ref(
+            'account_bank_statement_import_camt.camt_company_bank')
+        bank.journal_id.camt_import_batch = True
+        self._test_statement_import(
+            'account_bank_statement_import_camt', 'test-camt053.xml',
+            '2014-01-05-1234Test/1',
+            local_account=bank.acc_number,
             start_balance=15568.27, end_balance=15121.12,
             transactions=transactions
         )

--- a/account_bank_statement_import_camt/views/account_journal.xml
+++ b/account_bank_statement_import_camt/views/account_journal.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_account_journal_form_camt" model="ir.ui.view">
+            <field name="model">account.journal</field>
+            <field name="inherit_id" ref="account.view_account_journal_form" />
+            <field name="arch" type="xml">
+                <field name="sequence_id" position="after">
+                    <field name="camt_import_batch" attrs="{'invisible': [('type', '!=', 'bank')]}"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
A checkbox is added on the import wizard, when pressed, the CAMT import imports batch transactions as one transaction with the cumulative amount. Bank account number is left empty. 