### PR TITLE
CAMT import & reconciliation: Try to find a match using the EndToEndId field

### DIFF
--- a/account_bank_statement_import_camt_oca/__manifest__.py
+++ b/account_bank_statement_import_camt_oca/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'CAMT Format Bank Statements Import',
-    'version': '11.0.1.0.2',
+    'version': '11.0.1.0.3',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_camt_oca/models/__init__.py
+++ b/account_bank_statement_import_camt_oca/models/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import parser
 from . import account_bank_statement_import
+from . import account_bank_statement_line

--- a/account_bank_statement_import_camt_oca/models/account_bank_statement_line.py
+++ b/account_bank_statement_import_camt_oca/models/account_bank_statement_line.py
@@ -1,0 +1,43 @@
+from odoo import models
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = "account.bank.statement.line"
+
+    def get_reconciliation_proposition(self, excluded_ids=None):
+        """ Overridden to try & identify a reconciliation move_line for the
+            current statement line by using the reference to match a bank
+            payment line.
+
+            This works in the case where the bank_payment_line
+            `communication_type` is set to 'normal', as we then get the CAMT
+            Ntry's `EndToEndId` value in self.ref after parsing, which is the
+            Odoo bank_payment_line name if the related pain.001 file was
+            emitted through the OCA's bank-payment flow.
+        """
+
+        self.ensure_one()
+        if not excluded_ids:
+            excluded_ids = []
+
+        sql_query = """
+        SELECT aml.id
+        FROM account_move_line aml
+        JOIN account_payment_line apl ON apl.move_line_id = aml.id
+        JOIN bank_payment_line bpl ON bpl.id = apl.bank_line_id
+        WHERE bpl.name = %(ref)s
+        """
+        if excluded_ids:
+            sql_query = sql_query + ' AND aml.id NOT IN %(excluded_ids)s'
+
+        params = {
+            'ref': self.ref,
+            'excluded_ids': tuple(excluded_ids),
+        }
+
+        self.env.cr.execute(sql_query, params)
+        results = self.env.cr.fetchone()
+        if results:
+            return self.env['account.move.line'].browse(results[0])
+
+        return super().get_reconciliation_proposition(excluded_ids)


### PR DESCRIPTION
This PR adds code to try & find an `account.move.line` suitable for reconciliation of a statement line by checking in the database for a `bank.payment.line` which name would correspond to the value found in the `account.bank.statement.line` **ref** field.

This works in most 'vanilla' cases (localizations may introduce other values in the **ref** field) when payments have been emitted through the OCA's SEPA Credit Transfer modules: the `bank.payment.line` name is then set in the pain.001's `EndToEndId` field, which is present & unchanged in the related CAMT file Ntry.

- In case nothing is found, the behavior is unchanged

- In case the detection gets a false positive (CAMT Ntry's `EndToEndId` value matches a `bank.payment.line` name but they aren't linked), a wrong `account.move.line` is _suggested_ as a matching line in the reconciliation widget, which seems acceptable to me