### PR TITLE
[11.0 BUGFIX] Pass bytes to Ofxparse

### DIFF
--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -39,7 +39,7 @@ class AccountBankStatementImport(models.TransientModel):
         if not OfxParser:
             return False
         try:
-            ofx = OfxParser.parse(io.StringIO(data_file.decode('utf-8')))
+            ofx = OfxParser.parse(io.BytesIO(data_file))
         except Exception as e:
             _logger.debug(e)
             return False

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -38,7 +38,12 @@ class AccountBankStatementImport(models.TransientModel):
     def _check_ofx(self, data_file):
         if not OfxParser:
             return False
-        ofx = OfxParser.parse(io.BytesIO(data_file))
+
+        try:
+            ofx = OfxParser.parse(io.BytesIO(data_file))
+        except ValueError:
+            return False
+
         return ofx
 
     @api.model

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -65,7 +65,6 @@ class AccountBankStatementImport(models.TransientModel):
         return vals
 
     def _parse_file(self, data_file):
-        _logger.info('INSIDE OFX PARSER')
         ofx = self._check_ofx(data_file)
         if not ofx:
             return super(AccountBankStatementImport, self)._parse_file(

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -39,6 +39,7 @@ class AccountBankStatementImport(models.TransientModel):
         if not OfxParser:
             return False
         try:
+            ofx = OfxParser.parse(io.BytesIO(data_file))
             ofx = OfxParser.parse(io.StringIO(data_file.decode('utf-8')))
         except Exception as e:
             _logger.debug(e)

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -60,6 +60,7 @@ class AccountBankStatementImport(models.TransientModel):
         return vals
 
     def _parse_file(self, data_file):
+        _logger.info('INSIDE OFX PARSER')
         ofx = self._check_ofx(data_file)
         if not ofx:
             return super(AccountBankStatementImport, self)._parse_file(

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -38,7 +38,7 @@ class AccountBankStatementImport(models.TransientModel):
     def _check_ofx(self, data_file):
         if not OfxParser:
             return False
-        ofx = OfxParser.parse(io.StringIO(data_file.decode('utf-8')))
+        ofx = OfxParser.parse(io.BytesIO(data_file))
         return ofx
 
     @api.model

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -41,7 +41,7 @@ class AccountBankStatementImport(models.TransientModel):
 
         try:
             ofx = OfxParser.parse(io.BytesIO(data_file))
-        except ValueError:
+        except Exception:
             return False
 
         return ofx

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -38,12 +38,7 @@ class AccountBankStatementImport(models.TransientModel):
     def _check_ofx(self, data_file):
         if not OfxParser:
             return False
-        try:
-            ofx = OfxParser.parse(io.BytesIO(data_file))
-            ofx = OfxParser.parse(io.StringIO(data_file.decode('utf-8')))
-        except Exception as e:
-            _logger.debug(e)
-            return False
+        ofx = OfxParser.parse(io.StringIO(data_file.decode('utf-8')))
         return ofx
 
     @api.model

--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -39,7 +39,7 @@ class AccountBankStatementImport(models.TransientModel):
         if not OfxParser:
             return False
         try:
-            ofx = OfxParser.parse(io.BytesIO(data_file))
+            ofx = OfxParser.parse(io.StringIO(data_file.decode('utf-8')))
         except Exception as e:
             _logger.debug(e)
             return False


### PR DESCRIPTION
The ofx files have the correct charset inside their headers and
trying to convert the file to StringIO using a particular encoding
is subject to failures when the file isn't exactly an ascii file.

For example a file encoded with CP1252 with accents on letters like
é or è will not be parser as utf-8 and will fail to load.

Also since OfxParse is supposed to receive a file handle, it is
correctly reading the file header and choosing the appropriate charset
to read the rest of the file. For this reason, pass the bytes as a
ByteIO that doesn't care about the encoding.