### PR TITLE
[11.0][FIX] account_bank_statement_import_camt_oca: add tag AddtlInf to the name field

### DIFF
--- a/account_bank_statement_import_camt_oca/__manifest__.py
+++ b/account_bank_statement_import_camt_oca/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'CAMT Format Bank Statements Import',
-    'version': '11.0.1.0.3',
+    'version': '11.0.1.0.4',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_camt_oca/models/parser.py
+++ b/account_bank_statement_import_camt_oca/models/parser.py
@@ -56,7 +56,7 @@ class CamtParser(models.AbstractModel):
         # message
         self.add_value_from_node(
             ns, node, [
-                './ns:RmtInf/ns:Ustrd',
+                './ns:RmtInf/ns:Ustrd|./ns:RtrInf/ns:AddtlInf',
                 './ns:AddtlNtryInf',
                 './ns:Refs/ns:InstrId',
             ], transaction, 'name', join_str='\n')


### PR DESCRIPTION
This is the fix for https://github.com/OCA/bank-statement-import/issues/187, module `account_bank_statement_import_camt_oca` version 11.0