### PR TITLE
[10.0][FIX] account_bank_statement_import_camt: add tag AddtlInf to the name field

### DIFF
--- a/account_bank_statement_import_camt/__manifest__.py
+++ b/account_bank_statement_import_camt/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'CAMT Format Bank Statements Import',
-    'version': '10.0.1.1.4',
+    'version': '10.0.1.1.5',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -57,7 +57,7 @@ class CamtParser(models.AbstractModel):
         # message
         self.add_value_from_node(
             ns, node, [
-                './ns:RmtInf/ns:Ustrd',
+                './ns:RmtInf/ns:Ustrd|./ns:RtrInf/ns:AddtlInf',
                 './ns:AddtlNtryInf',
                 './ns:Refs/ns:InstrId',
             ], transaction, 'name', join_str='\n')


### PR DESCRIPTION
Backport of https://github.com/OCA/bank-statement-import/pull/189 to V10.
This is the fix for #187, module account_bank_statement_import_camt version 10.0.

