### PR TITLE
[IMP] account_bank_statement_import_paypal: create paypal maps

### DIFF
--- a/account_bank_statement_import_paypal/README.rst
+++ b/account_bank_statement_import_paypal/README.rst
@@ -25,7 +25,8 @@ Import Paypal Bank Statements
 
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
-This module allows you to import the Paypal CSV files in Odoo as bank statements.
+This module allows you to import the Paypal CSV files in Odoo as bank
+statements.
 
 **Table of contents**
 
@@ -35,18 +36,18 @@ This module allows you to import the Paypal CSV files in Odoo as bank statements
 Configuration
 =============
 
-In the menu Accounting > Configuration > Accounting > Bank Accounts,
-make sure that you have your Paypal bank account with the following parameters:
-* Bank Account Type: Normal Bank Account
-* Account Number: the email address associated with your Paypal account
-* Account Journal: the journal associated to your Paypal account
+* Create or go to a bank journal where you want to import Paypal statement.
+* Edit that journal and set a Paypal map in **Paypal Map** section in **Advanced
+  Settings** tab.
 
-TIPS
-~~~~
-For now only French and English report are supported.
-For adding new support you just need to add your header in
-model/account_bank_statement_import_paypal.py in the variables HEADERS.
-Please help us and do a PR for adding new header ! Thanks
+* Now you can import Paypal statements in that journal.
+
+Note: if existent Paypal Map does not fit to your file to import, you can
+create another map in **Invoicing > Configuration > Accounting > Paypal
+Mapping**.
+
+You can import headers from any Paypal file in **Action > Create Paypal Map
+Lines** and set every line with which field of statement have to match.
 
 Usage
 =====

--- a/account_bank_statement_import_paypal/__init__.py
+++ b/account_bank_statement_import_paypal/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/account_bank_statement_import_paypal/__manifest__.py
+++ b/account_bank_statement_import_paypal/__manifest__.py
@@ -5,14 +5,22 @@
 {
     "name": "Import Paypal Bank Statements",
     'summary': 'Import Paypal CSV files as Bank Statements in Odoo',
-    "version": "11.0.1.0.0",
+    "version": "11.0.2.0.0",
     "category": "Accounting",
     "website": "https://github.com/OCA/bank-statement-import",
     "author": " Akretion, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "application": False,
     "installable": True,
     "depends": [
         "account_bank_statement_import",
+        "sale",
     ],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/paypal_map_data.xml",
+        "wizards/create_map_lines_from_file_views.xml",
+        "wizards/account_bank_statement_import_view.xml",
+        "views/account_journal_views.xml",
+        "views/paypal_map_views.xml",
+    ]
 }

--- a/account_bank_statement_import_paypal/data/paypal_map_data.xml
+++ b/account_bank_statement_import_paypal/data/paypal_map_data.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="paypal_map" model="account.bank.statement.import.paypal.map">
+        <field name="name">Paypal Monthly Statement</field>
+    </record>
+
+    <record id="paypal_map_line_date" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Date</field>
+        <field name="sequence">0</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">date</field>
+        <field name="date_format">%m/%d/%Y</field>
+    </record>
+    <record id="paypal_map_line_time" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Time</field>
+        <field name="sequence">1</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">time</field>
+    </record>
+    <record id="paypal_map_line_time_zone" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Time Zone</field>
+        <field name="sequence">2</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+    </record>
+    <record id="paypal_map_line_description" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Description</field>
+        <field name="sequence">3</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">description</field>
+    </record>
+    <record id="paypal_map_line_currency" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Currency</field>
+        <field name="sequence">4</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">currency</field>
+    </record>
+    <record id="paypal_map_line_gross" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Gross</field>
+        <field name="sequence">5</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">amount</field>
+    </record>
+    <record id="paypal_map_line_fee" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Fee</field>
+        <field name="sequence">6</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">commission</field>
+    </record>
+    <record id="paypal_map_line_net" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Net</field>
+        <field name="sequence">7</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+    </record>
+    <record id="paypal_map_line_balance" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Balance</field>
+        <field name="sequence">8</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">balance</field>
+    </record>
+    <record id="paypal_map_line_transaction" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Transaction ID</field>
+        <field name="sequence">9</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">transaction_id</field>
+    </record>
+    <record id="paypal_map_line_email" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">From Email Address</field>
+        <field name="sequence">10</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">email</field>
+    </record>
+    <record id="paypal_map_line_name" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Name</field>
+        <field name="sequence">11</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">partner_name</field>
+    </record>
+    <record id="paypal_map_line_bank_name" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Bank Name</field>
+        <field name="sequence">12</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">bank_name</field>
+    </record>
+    <record id="paypal_map_line_bank_account" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Bank Account</field>
+        <field name="sequence">13</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">bank_account</field>
+    </record>
+    <record id="paypal_map_line_shipping" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Shipping and Handling Amount</field>
+        <field name="sequence">14</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+    </record>
+    <record id="paypal_map_line_sales" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Sales Tax</field>
+        <field name="sequence">15</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+    </record>
+    <record id="paypal_map_line_invoice" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Invoice ID</field>
+        <field name="sequence">16</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">invoice_number</field>
+    </record>
+    <record id="paypal_map_line_reference" model="account.bank.statement.import.paypal.map.line">
+        <field name="name">Reference Txn ID</field>
+        <field name="sequence">17</field>
+        <field name="map_parent_id" ref="paypal_map"/>
+        <field name="field_to_assign">origin_transaction_id</field>
+    </record>
+
+</odoo>

--- a/account_bank_statement_import_paypal/i18n/es.po
+++ b/account_bank_statement_import_paypal/i18n/es.po
@@ -1,238 +1,243 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* account_bank_statement_import_paypal
+# 	* account_bank_statement_import_paypal
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-11 10:43+0000\n"
-"PO-Revision-Date: 2019-01-11 10:43+0000\n"
-"Last-Translator: <>\n"
+"PO-Revision-Date: 2019-01-11 11:44+0100\n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 2.1.1\n"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.create_paypal_map_lines_view
 msgid "All the Paypal map lines will be created automatically."
-msgstr ""
+msgstr "Todas las lineas de la plantilla se crearán automáticamente."
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Balance"
-msgstr ""
+msgstr "Saldo"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Bank Account"
-msgstr ""
+msgstr "Cuenta bancaria"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Bank Name"
-msgstr ""
+msgstr "Nombre del banco"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create_data_file
 msgid "Bank Statement File"
-msgstr ""
+msgstr "Archivo de extracto bancario"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.create_paypal_map_lines_view
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.create_paypal_map_lines_view
 msgid "Choose a file to import..."
-msgstr ""
+msgstr "Escoja un archivo a importar..."
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.create_paypal_map_lines_view
 msgid "Create Lines"
-msgstr ""
+msgstr "Crear líneas"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.actions.act_window,name:account_bank_statement_import_paypal.action_create_paypal_map_lines
 msgid "Create Paypal Map Lines"
-msgstr ""
+msgstr "Crear las líneas de la plantilla de Paypal"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_create_uid
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_create_uid
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create_create_uid
 msgid "Created by"
-msgstr ""
+msgstr "Creado el"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_create_date
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_create_date
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create_create_date
 msgid "Created on"
-msgstr ""
+msgstr "Creado por"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Currency"
-msgstr ""
+msgstr "Moneda"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Date"
-msgstr ""
+msgstr "Fecha"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_date_format
 msgid "Date Format"
-msgstr ""
+msgstr "Formato de fecha"
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py:90
 #, python-format
 msgid "Date format of map file and Paypal date does not match."
 msgstr ""
+"El format de fecha del archivo de plantilla y la fecha de Paypal no "
+"coinciden."
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_display_name
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_display_name
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create_display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nombre mostrado"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.create_paypal_map_lines_view
 msgid "Download a bank statement from your bank and import it here."
-msgstr ""
+msgstr "Descargue un extracto bancario desde su banco e impórtelo aquí."
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Fee"
-msgstr ""
+msgstr "Tarifa"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_sequence
 msgid "Field number"
-msgstr ""
+msgstr "Nº de campo"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create_filename
 msgid "Filename"
-msgstr ""
+msgstr "Nombre de archivo"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "From Email Address"
-msgstr ""
+msgstr "Correo electrónico del remitente"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Gross"
-msgstr ""
+msgstr "Bruto"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_name
 msgid "Header Name"
-msgstr ""
+msgstr "Nombre de la cabecera"
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py:73
 #, python-format
 msgid "Headers of file to import and Paypal map lines does not match."
 msgstr ""
+"La cabecera del archivo a importar y las lineas de la plantilla de Paypal no "
+"coinciden."
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_id
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_id
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create_id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model,name:account_bank_statement_import_paypal.model_account_bank_statement_import
 msgid "Import Bank Statement"
-msgstr ""
+msgstr "Importar Extracto Bancario"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.create_paypal_map_lines_view
 msgid "Import Paypal Map Lines"
-msgstr ""
+msgstr "Importar las lineas de la plantilla de Paypal"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Invoice ID"
-msgstr ""
+msgstr "Número de factura"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model,name:account_bank_statement_import_paypal.model_account_journal
 msgid "Journal"
-msgstr ""
+msgstr "Diario"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map___last_update
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line___last_update
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create___last_update
 msgid "Last Modified on"
-msgstr ""
+msgstr "Última modificación en"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_write_uid
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_write_uid
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create_write_uid
 msgid "Last Updated by"
-msgstr ""
+msgstr "Última actualización por"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_write_date
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_write_date
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_wizard_paypal_map_create_write_date
 msgid "Last Updated on"
-msgstr ""
+msgstr "Última actualización en"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_map_parent_id
 msgid "Map Parent"
-msgstr ""
+msgstr "Plantilla padre"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_map_line_ids
 msgid "Map lines"
-msgstr ""
+msgstr "Líneas de la plantilla"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.statement_import_map_tax_form
 msgid "Mapping Lines"
-msgstr ""
+msgstr "Líneas de la plantilla"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_name
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Origin Transaction ID"
-msgstr ""
+msgstr "Id. de transacción"
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py:226
 #, python-format
 msgid "PAYPAL-COSTS"
-msgstr ""
+msgstr "COSTES-PAYPAL"
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py:191
 #, python-format
 msgid "PayPal Import %s > %s"
-msgstr ""
+msgstr "Importación de Paypal %s > %s"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_journal_paypal_map_id
@@ -240,100 +245,104 @@ msgstr ""
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.statement_import_map_tax_tree
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.view_account_journal_form_n43
 msgid "Paypal Map"
-msgstr ""
+msgstr "Plantilla de Paypal"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.actions.act_window,name:account_bank_statement_import_paypal.action_statement_import_paypal_mappging
 #: model:ir.ui.menu,name:account_bank_statement_import_paypal.menu_statement_import_paypal_mapping
 msgid "Paypal Mapping"
-msgstr ""
+msgstr "Plantilla de Paypal"
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py:225
 #, python-format
 msgid "Paypal commissions"
-msgstr ""
+msgstr "Tarifa de Paypal"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_id_4185
 msgid "Paypal map"
-msgstr ""
+msgstr "Plantilla de Paypal"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.statement_import_map_tax_line_form
 msgid "Paypal mapping line"
-msgstr ""
+msgstr "Línea de plantilla de Paypal"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.statement_import_map_tax_line_tree
 msgid "Paypal mapping lines"
-msgstr ""
+msgstr "Líneas de plantilla de Paypal"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.account_bank_statement_import_view
 msgid "Paypal with Template:"
-msgstr ""
+msgstr "Paypal con la plantilla:"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.ui.view,arch_db:account_bank_statement_import_paypal.create_paypal_map_lines_view
-msgid "Select a Paypal bank statement file to create all the map lines from headers file."
+msgid ""
+"Select a Paypal bank statement file to create all the map lines from headers "
+"file."
 msgstr ""
+"Seleccione un archivo de extracto bancario de Paypal para crear todas las "
+"lineas de la plantilla a partir de la cabecera del archivo."
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_map_line_field_to_assign
 msgid "Statement Field to Assign"
-msgstr ""
+msgstr "Campo del extracto a asignar"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Time"
-msgstr ""
+msgstr "Hora"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,field_to_assign:0
 msgid "Transaction ID"
-msgstr ""
+msgstr "Id. de transacción"
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py:100
 #, python-format
 msgid "Value '%s' for the field '%s' on line %d, cannot be converted to float"
 msgstr ""
+"El valor '%s' del campo '%s' en la línea %d, no se puede convertir a float"
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py:137
 #, python-format
 msgid "You must run this wizard from the journal"
-msgstr ""
+msgstr "Debe ejecutar este asistente des del diario"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model,name:account_bank_statement_import_paypal.model_account_bank_statement_import_paypal_map
 msgid "account.bank.statement.import.paypal.map"
-msgstr ""
+msgstr "account.bank.statement.import.paypal.map"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model,name:account_bank_statement_import_paypal.model_account_bank_statement_import_paypal_map_line
 msgid "account.bank.statement.import.paypal.map.line"
-msgstr ""
+msgstr "account.bank.statement.import.paypal.map.line"
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py:122
 #, python-format
 msgid "currency %s on line %d cannot be found in odoo"
-msgstr ""
+msgstr "la monea %s de la línea %d no se puede encontrar en odoo"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,date_format:0
 msgid "i.e. 12/15/2019"
-msgstr ""
+msgstr "p.e. 12/15/2019"
 
 #. module: account_bank_statement_import_paypal
 #: selection:account.bank.statement.import.paypal.map.line,date_format:0
 msgid "i.e. 15/12/2019"
-msgstr ""
+msgstr "p.e. 15/12/2019"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model,name:account_bank_statement_import_paypal.model_wizard_paypal_map_create
 msgid "wizard.paypal.map.create"
-msgstr ""
-
+msgstr "wizard.paypal.map.create"

--- a/account_bank_statement_import_paypal/models/__init__.py
+++ b/account_bank_statement_import_paypal/models/__init__.py
@@ -1,1 +1,2 @@
-from . import account_bank_statement_import_paypal
+from . import account_bank_statement_import_paypal_map
+from . import account_journal

--- a/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_map.py
+++ b/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_map.py
@@ -1,0 +1,64 @@
+# Copyright 2019 Tecnativa - Vicent Cubells
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountBankStatementImportPaypalMap(models.Model):
+    _name = 'account.bank.statement.import.paypal.map'
+
+    name = fields.Char(
+        required=True,
+    )
+    map_line_ids = fields.One2many(
+        comodel_name='account.bank.statement.import.paypal.map.line',
+        inverse_name='map_parent_id',
+        string="Map lines",
+        required=True,
+        copy=True,
+    )
+
+
+class AccountBankStatementImportPaypalMapLIne(models.Model):
+    _name = 'account.bank.statement.import.paypal.map.line'
+    _order = "sequence asc, id asc"
+
+    sequence = fields.Integer(
+        string="Field number",
+        required=True,
+    )
+    name = fields.Char(
+        string="Header Name",
+        required=True,
+    )
+    map_parent_id = fields.Many2one(
+        comodel_name='account.bank.statement.import.paypal.map',
+        required=True,
+        ondelete='cascade',
+    )
+    field_to_assign = fields.Selection(
+        selection=[
+            ('date', 'Date'),
+            ('time', 'Time'),
+            ('description', 'Description'),
+            ('currency', 'Currency'),
+            ('amount', 'Gross'),
+            ('commission', 'Fee'),
+            ('balance', 'Balance'),
+            ('transaction_id', 'Transaction ID'),
+            ('email', 'From Email Address'),
+            ('partner_name', 'Name'),
+            ('bank_name', 'Bank Name'),
+            ('bank_account', 'Bank Account'),
+            ('invoice_number', 'Invoice ID'),
+            ('origin_transaction_id', 'Origin Transaction ID'),
+        ],
+        string="Statement Field to Assign",
+    )
+    date_format = fields.Selection(
+        selection=[
+            ('%d/%m/%Y', 'i.e. 15/12/2019'),
+            ('%m/%d/%Y', 'i.e. 12/15/2019'),
+        ],
+        string="Date Format",
+    )

--- a/account_bank_statement_import_paypal/models/account_journal.py
+++ b/account_bank_statement_import_paypal/models/account_journal.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Tecnativa - Vicent Cubells
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    paypal_map_id = fields.Many2one(
+        comodel_name='account.bank.statement.import.paypal.map',
+        string='Paypal Map',
+    )

--- a/account_bank_statement_import_paypal/readme/CONFIGURE.rst
+++ b/account_bank_statement_import_paypal/readme/CONFIGURE.rst
@@ -1,12 +1,12 @@
-In the menu Accounting > Configuration > Accounting > Bank Accounts,
-make sure that you have your Paypal bank account with the following parameters:
-* Bank Account Type: Normal Bank Account
-* Account Number: the email address associated with your Paypal account
-* Account Journal: the journal associated to your Paypal account
+* Create or go to a bank journal where you want to import Paypal statement.
+* Edit that journal and set a Paypal map in **Paypal Map** section in **Advanced
+  Settings** tab.
 
-TIPS
-~~~~
-For now only French and English report are supported.
-For adding new support you just need to add your header in
-model/account_bank_statement_import_paypal.py in the variables HEADERS.
-Please help us and do a PR for adding new header ! Thanks
+* Now you can import Paypal statements in that journal.
+
+Note: if existent Paypal Map does not fit to your file to import, you can
+create another map in **Invoicing > Configuration > Accounting > Paypal
+Mapping**.
+
+You can import headers from any Paypal file in **Action > Create Paypal Map
+Lines** and set every line with which field of statement have to match.

--- a/account_bank_statement_import_paypal/readme/DESCRIPTION.rst
+++ b/account_bank_statement_import_paypal/readme/DESCRIPTION.rst
@@ -1,1 +1,2 @@
-This module allows you to import the Paypal CSV files in Odoo as bank statements.
+This module allows you to import the Paypal CSV files in Odoo as bank
+statements.

--- a/account_bank_statement_import_paypal/security/ir.model.access.csv
+++ b/account_bank_statement_import_paypal/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+access_account_bank_statement_import_paypal_map,Paypal map manager,model_account_bank_statement_import_paypal_map,account.group_account_manager,1,1,1,1
+access_account_bank_statement_import_paypal_map_line,Paypal map line manager,model_account_bank_statement_import_paypal_map_line,account.group_account_manager,1,1,1,1

--- a/account_bank_statement_import_paypal/static/description/index.html
+++ b/account_bank_statement_import_paypal/static/description/index.html
@@ -368,41 +368,38 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/bank-statement-import/tree/11.0/account_bank_statement_import_paypal"><img alt="OCA/bank-statement-import" src="https://img.shields.io/badge/github-OCA%2Fbank--statement--import-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/bank-statement-import-11-0/bank-statement-import-11-0-account_bank_statement_import_paypal"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/174/11.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
-<p>This module allows you to import the Paypal CSV files in Odoo as bank statements.</p>
+<p>This module allows you to import the Paypal CSV files in Odoo as bank
+statements.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#configuration" id="id1">Configuration</a><ul>
-<li><a class="reference internal" href="#tips" id="id2">TIPS</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#id1">Configuration</a></h1>
-<p>In the menu Accounting &gt; Configuration &gt; Accounting &gt; Bank Accounts,
-make sure that you have your Paypal bank account with the following parameters:
-* Bank Account Type: Normal Bank Account
-* Account Number: the email address associated with your Paypal account
-* Account Journal: the journal associated to your Paypal account</p>
-<div class="section" id="tips">
-<h2><a class="toc-backref" href="#id2">TIPS</a></h2>
-<p>For now only French and English report are supported.
-For adding new support you just need to add your header in
-model/account_bank_statement_import_paypal.py in the variables HEADERS.
-Please help us and do a PR for adding new header ! Thanks</p>
-</div>
+<ul class="simple">
+<li>Create or go to a bank journal where you want to import Paypal statement.</li>
+<li>Edit that journal and set a Paypal map in <strong>Paypal Map</strong> section in <strong>Advanced
+Settings</strong> tab.</li>
+<li>Now you can import Paypal statements in that journal.</li>
+</ul>
+<p>Note: if existent Paypal Map does not fit to your file to import, you can
+create another map in <strong>Invoicing &gt; Configuration &gt; Accounting &gt; Paypal
+Mapping</strong>.</p>
+<p>You can import headers from any Paypal file in <strong>Action &gt; Create Paypal Map
+Lines</strong> and set every line with which field of statement have to match.</p>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id3">Usage</a></h1>
+<h1><a class="toc-backref" href="#id2">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to Paypal and download your Bank Statement</li>
@@ -411,7 +408,7 @@ Please help us and do a PR for adding new header ! Thanks</p>
 <img alt="." src="https://raw.githubusercontent.com/OCA/bank-statement-import/11.0/account_bank_statement_import_paypal/static/description/paypal_backoffice.png" />
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/bank-statement-import/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -419,15 +416,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id5">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id6">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Akretion</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li>Alexis de Lattre &lt;<a class="reference external" href="mailto:alexis.delattre&#64;akretion.com">alexis.delattre&#64;akretion.com</a>&gt;</li>
 <li>Sebastien BEAU &lt;<a class="reference external" href="mailto:sebastien.beau&#64;akretion.com">sebastien.beau&#64;akretion.com</a>&gt;</li>
@@ -438,7 +435,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/account_bank_statement_import_paypal/tests/__init__.py
+++ b/account_bank_statement_import_paypal/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_paypal_statement_import

--- a/account_bank_statement_import_paypal/tests/paypal_en.csv
+++ b/account_bank_statement_import_paypal/tests/paypal_en.csv
@@ -1,0 +1,3 @@
+"Date","Time","Time Zone","Description","Currency","Gross","Fee ","Net","Balance","Transaction ID","From Email Address","Name","Bank Name","Bank Account","Shipping and Handling Amount","Sales Tax","Invoice ID","Reference Txn ID"
+"12/15/2018","20:07:53","CET","Your best supplier","USD","-33,50","-2,3","-31,2","-31,2","53820712527632627","","John Doe","Bank of America","123456789","0","0","INV25","23"
+"12/15/2018","22:07:53","CET","Your payment","USD","525","0","525","493,80","34731322767782103","","Agrolait","","","0","0","INV/2019/0003","24"

--- a/account_bank_statement_import_paypal/tests/test_paypal_statement_import.py
+++ b/account_bank_statement_import_paypal/tests/test_paypal_statement_import.py
@@ -1,0 +1,54 @@
+# Copyright 2019 Tecnativa - Vicent Cubells
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import os
+import base64
+from odoo.tests import common
+
+
+class TestPaypalFile(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestPaypalFile, cls).setUpClass()
+
+        cls.map = cls.env['account.bank.statement.import.paypal.map'].create({
+            'name': 'Paypal Map Test',
+        })
+        cls.journal = cls.env['account.journal'].create({
+            'name': 'Paypal Bank',
+            'type': 'bank',
+            'code': 'PYPAL',
+        })
+
+    def _do_import(self, file_name):
+        file_name = os.path.join(os.path.dirname(__file__), file_name)
+        return open(file_name).read()
+
+    def test_import_header(self):
+        file = self._do_import('paypal_en.csv')
+        file = base64.b64encode(file.encode("utf-8"))
+        wizard = self.env['wizard.paypal.map.create'].with_context({
+            'journal_id': self.journal.id,
+            'active_ids': [self.map.id],
+        }).create({'data_file': file})
+        wizard.create_map_lines()
+        self.assertEqual(len(self.map.map_line_ids.ids), 18)
+
+    def test_import_paypal_file(self):
+        # Current statements before to run the wizard
+        old_statements = self.env['account.bank.statement'].search([])
+        # This journal is for Paypal statements
+        map = self.env.ref('account_bank_statement_import_paypal.paypal_map')
+        self.journal.paypal_map_id = map.id
+        file = self._do_import('paypal_en.csv')
+        file = base64.b64encode(file.encode("utf-8"))
+        wizard = self.env['account.bank.statement.import'].with_context({
+            'journal_id': self.journal.id,
+        }).create({'data_file': file})
+        wizard.import_file()
+        staments_now = self.env['account.bank.statement'].search([])
+        statement = staments_now - old_statements
+        self.assertEqual(len(statement.line_ids), 3)
+        self.assertEqual(len(statement.mapped('line_ids').filtered(
+            lambda x: x.partner_id and x.account_id)), 1)
+        self.assertAlmostEqual(sum(statement.mapped('line_ids.amount')), 489.2)

--- a/account_bank_statement_import_paypal/views/account_journal_views.xml
+++ b/account_bank_statement_import_paypal/views/account_journal_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_journal_form_n43" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='advanced_settings']/group" position="inside">
+                <group string="Paypal Map" attrs="{'invisible': [('type','!=','bank')]}">
+                    <field name="paypal_map_id"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_bank_statement_import_paypal/views/paypal_map_views.xml
+++ b/account_bank_statement_import_paypal/views/paypal_map_views.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="statement_import_map_tax_tree" model="ir.ui.view">
+        <field name="model">account.bank.statement.import.paypal.map</field>
+        <field name="arch" type="xml">
+            <tree string="Paypal Map">
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="statement_import_map_tax_form" model="ir.ui.view">
+        <field name="model">account.bank.statement.import.paypal.map</field>
+        <field name="arch" type="xml">
+            <form string="Paypal Map">
+                <group>
+                    <field name="name"/>
+                </group>
+                <separator string="Mapping Lines"/>
+                <field name="map_line_ids"/>
+            </form>
+        </field>
+    </record>
+
+    <record id="statement_import_map_tax_line_tree" model="ir.ui.view">
+        <field name="model">account.bank.statement.import.paypal.map.line</field>
+        <field name="arch" type="xml">
+            <tree string="Paypal mapping lines" editable="bottom">
+                <field name="sequence"/>
+                <field name="name"/>
+                <field name="field_to_assign"/>
+                <field name="date_format" attrs="{'readonly':[('field_to_assign','!=','date')], 'required':[('field_to_assign','=','date')]}"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="statement_import_map_tax_line_form" model="ir.ui.view">
+        <field name="model">account.bank.statement.import.paypal.map.line</field>
+        <field name="arch" type="xml">
+            <form string="Paypal mapping line">
+                <group>
+                    <group>
+                        <field name="name"/>
+                        <field name="sequence"/>
+                        <field name="field_to_assign"/>
+                    </group>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="action_statement_import_paypal_mappging">
+        <field name="name">Paypal Mapping</field>
+        <field name="res_model">account.bank.statement.import.paypal.map</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_statement_import_paypal_mapping"
+              parent="account.account_account_menu"
+              action="action_statement_import_paypal_mappging"
+              name="Paypal Mapping"/>
+
+</odoo>

--- a/account_bank_statement_import_paypal/wizards/__init__.py
+++ b/account_bank_statement_import_paypal/wizards/__init__.py
@@ -1,0 +1,2 @@
+from . import create_map_lines_from_file
+from . import account_bank_statement_import_paypal

--- a/account_bank_statement_import_paypal/wizards/account_bank_statement_import_view.xml
+++ b/account_bank_statement_import_paypal/wizards/account_bank_statement_import_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="account_bank_statement_import_view" model="ir.ui.view">
+        <field name="model">account.bank.statement.import</field>
+        <field name="inherit_id" ref="account_bank_statement_import.account_bank_statement_import_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//ul[@id='statement_format']" position="inside">
+                <li>Paypal with Template: <field name="paypal_map_id"/></li>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_bank_statement_import_paypal/wizards/create_map_lines_from_file.py
+++ b/account_bank_statement_import_paypal/wizards/create_map_lines_from_file.py
@@ -1,0 +1,38 @@
+# Copyright 2019 Tecnativa - Vicent Cubells
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import csv
+import base64
+from odoo import api, fields, models
+from io import StringIO
+
+
+class WizardPaypalMapCreate(models.TransientModel):
+    _name = 'wizard.paypal.map.create'
+
+    data_file = fields.Binary(
+        string='Bank Statement File',
+        required=True,
+    )
+    filename = fields.Char()
+
+    @api.multi
+    def create_map_lines(self):
+        statement_obj = self.env['account.bank.statement.import.paypal.map']
+        data_file = base64.b64decode(self.data_file)
+        if not isinstance(data_file, str):
+            data_file = data_file.decode('utf-8-sig').strip()
+        file = StringIO(data_file)
+        file.seek(0)
+        reader = csv.reader(file)
+        headers = []
+        for row in reader:
+            headers = row
+            break
+        lines = []
+        for idx, title in enumerate(headers):
+            lines.append((0, 0, {'sequence': idx, 'name': title}))
+        if lines:
+            for statement in statement_obj.browse(
+                    self.env.context.get('active_ids')):
+                statement.map_line_ids = lines

--- a/account_bank_statement_import_paypal/wizards/create_map_lines_from_file_views.xml
+++ b/account_bank_statement_import_paypal/wizards/create_map_lines_from_file_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="create_paypal_map_lines_view" model="ir.ui.view">
+        <field name="name">Create Paypal Map Lines</field>
+        <field name="model">wizard.paypal.map.create</field>
+        <field name="arch" type="xml">
+            <form string="Import Paypal Map Lines">
+                <h2>Select a Paypal bank statement file to create all the map lines from headers file.</h2>
+                <p>Download a bank statement from your bank and import it here.</p>
+                <p>All the Paypal map lines will be created automatically.</p>
+                <field name="data_file" filename="filename" placeholder="Choose a file to import..."/>
+                <field name="filename" invisible="1"/>
+                <footer>
+                    <button name="create_map_lines" string="Create Lines" type="object" class="btn-primary" />
+                    <button string="Cancel" class="btn-default" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+    <act_window name="Create Paypal Map Lines"
+            res_model="wizard.paypal.map.create"
+            src_model="account.bank.statement.import.paypal.map"
+            view_mode="form"
+            target="new"
+            key2="client_action_multi"
+            id="action_create_paypal_map_lines"/>
+
+</odoo>


### PR DESCRIPTION
Several changes to allow create Paypal templates. Now user can create a map for any Paypal statement he downloads:
- new model to set template and import headers easily.
- updated README.
- added tests.
- added translation.
- fix several bugs.

cc @Tecnativa