### PR TITLE
[FIX] be sure transactions resulting from NtryDtls nodes have a unique id

### DIFF
--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -180,9 +180,13 @@ class CamtParser(models.AbstractModel):
             yield transaction
             return
         transaction_base = transaction
+        transaction_base_id = transaction_base['unique_import_id']
         for i, dnode in enumerate(details_nodes):
             transaction = copy(transaction_base)
             self.parse_transaction_details(ns, dnode, transaction)
+            if transaction_base_id == transaction['unique_import_id']:
+                # if parse_transaction_details didn't uniquify ids, do it here
+                transaction['unique_import_id'] += i and '-%s' % i or ''
             # transactions['data'] should be a synthetic xml snippet which
             # contains only the TxDtls that's relevant.
             # only set this field if statement lines have it


### PR DESCRIPTION
this often works (for example in our test files) because depending on the statement id, we change the statement id after parsing transactions, which in turn updates all statement line ids in https://github.com/OCA/bank-statement-import/blob/8.0/account_bank_statement_import_camt/models/parser.py#L257

But well, if the statement id coming from the file already has the execution date, this doesn't happen and then all details transactions have the same id without this.