### PR TITLE
[10.0][camt_details] Add more address lines information when parsing camt

### DIFF
--- a/account_bank_statement_import_camt/test_files/test-camt053
+++ b/account_bank_statement_import_camt/test_files/test-camt053
@@ -262,8 +262,8 @@
                             <Dbtr>
                                 <Nm>3rd party Media</Nm>
                                 <PstlAdr>
-                                    <StrtNm>SOMESTREET 570-A</StrtNm>
-                                    <TwnNm>1276 ML HOUSCITY</TwnNm>
+                                    <AdrLine>SOMESTREET 570-A</AdrLine>
+                                    <AdrLine>1276 ML HOUSCITY</AdrLine>
                                     <Ctry>NL</Ctry>
                                 </PstlAdr>
                             </Dbtr>

--- a/account_bank_statement_import_camt_details/models/camt_parser.py
+++ b/account_bank_statement_import_camt_details/models/camt_parser.py
@@ -33,6 +33,13 @@ class CamtDetailsParser(models.AbstractModel):
                 './ns:BldgNb', namespaces={'ns': ns})
             if building_node:
                 address_values['building'] = building_node[0].text
+            generic_nodes = address_node[0].xpath(
+                './ns:AdrLine', namespaces={'ns': ns})
+            if generic_nodes:
+                address_values.update({
+                    'address_line_' + str(i): node.text
+                    for i, node in enumerate(generic_nodes)
+                })
             zip_node = address_node[0].xpath(
                 './ns:PstCd', namespaces={'ns': ns})
             if zip_node:
@@ -58,7 +65,8 @@ class CamtDetailsParser(models.AbstractModel):
         """
         Hook for formatting the partner address read in CAMT bank statement.
         :param address_values: dict: all address values found in statement
-            Possible keys are ['street', 'building', 'zip', 'city']
+            Possible keys are ['street', 'building', 'address_line_xxx',
+                               'zip', 'city']
             Not all keys may be present.
         :return: str: formatted address
         """


### PR DESCRIPTION
In some CAMT statement lines, the address can either be well formatted into street, zip, city XML tags, but sometimes it's not the case and it's only provided inside more generic <AdrLine> tags.

This small addition enable to parse more address information from the statement for the later case without changing the current behaviour.