### PR TITLE
[10.0] FIX amount when currency is not default

### DIFF
--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -76,6 +76,14 @@ class CamtParser(models.AbstractModel):
             transaction, 'ref'
         )
         amount = self.parse_amount(ns, node)
+
+        # Tx conversion devise
+        xchgrate = node.xpath(
+            '../../ns:AmtDtls/ns:TxAmt/ns:CcyXchg/ns:XchgRate', namespaces={'ns': ns})
+        # If there is a tx, then we do the conversion
+        if xchgrate:
+            amount = amount * float(xchgrate[0].text)
+
         if amount != 0.0:
             transaction['amount'] = amount
         # remote party values


### PR DESCRIPTION
There were some cases where a transaction can be in another currency and when camt_details is installed, the currency is ignored.

This fix does the currency conversion properly.