### PR TITLE
Manage multi-bank-account in statement import

### DIFF
--- a/account_bank_statement_import_camt_oca/models/account_bank_statement_import.py
+++ b/account_bank_statement_import_camt_oca/models/account_bank_statement_import.py
@@ -4,6 +4,7 @@ import logging
 from io import BytesIO
 import zipfile
 from odoo import api, models
+from odoo.addons.base.models.res_bank import sanitize_account_number
 
 _logger = logging.getLogger(__name__)
 
@@ -12,24 +13,87 @@ class AccountBankStatementImport(models.TransientModel):
     _inherit = 'account.bank.statement.import'
 
     @api.model
+    def _xml_split_file(self, data_file):
+        """BNP France is known to merge xml files"""
+        if not data_file.startswith(b'<?xml'):
+            return [data_file]
+        data_file_elements = []
+        all_files = data_file.split(b'<?xml')
+        for file in all_files:
+            if file:
+                data_file_elements.append(b'<?xml' + file)
+        return data_file_elements
+
+    @api.model
     def _parse_file(self, data_file):
         """Parse a CAMT053 XML file."""
         try:
             parser = self.env['account.bank.statement.import.camt.parser']
             _logger.debug("Try parsing with camt.")
-            return parser.parse(data_file)
+            currency = None
+            account_number = None
+            transactions = []
+            data_file_elements = self._xml_split_file(data_file)
+            for data_file_element in data_file_elements:
+                currency, account_number, element_transactions = parser.parse(
+                    data_file_element
+                )
+                transactions.extend(element_transactions)
+            return currency, account_number, transactions
         except ValueError:
             try:
                 with zipfile.ZipFile(BytesIO(data_file)) as data:
+                    journal_account_number = None
+                    journal_currency_name = None
+                    if self.env.context.get('journal_id', None):
+                        journal_id = self.env.context.get('journal_id', None)
+                        journal = self.env['account.journal'].browse(
+                            journal_id
+                        )
+                        journal_account_number = sanitize_account_number(
+                            journal.bank_account_id.acc_number
+                        )
+                        journal_currency_name = journal.currency_id.name
+
                     currency = None
                     account_number = None
                     transactions = []
                     for member in data.namelist():
+                        old_account_number = account_number
+                        old_currency = currency
                         currency, account_number, new = self._parse_file(
                             data.open(member).read()
                         )
+                        if (
+                            journal_account_number
+                            and journal_account_number != account_number
+                        ):
+                            continue
+                        if (
+                            not journal_account_number
+                            and old_account_number
+                            and old_account_number != account_number
+                        ):
+                            raise ValueError(
+                                'File containing statements for multiple '
+                                'accounts'
+                            )
+                        if (
+                            journal_currency_name
+                            and journal_currency_name != currency
+                        ):
+                            continue
+                        if (
+                            not journal_currency_name
+                            and old_currency
+                            and old_currency != currency
+                        ):
+                            raise ValueError(
+                                'File containing statements for multiple '
+                                'currencies'
+                            )
                         transactions.extend(new)
-                return currency, account_number, transactions
+                    return currency, account_number, transactions
             except (zipfile.BadZipFile, ValueError):
                 pass
             # Not a camt file, returning super will call next candidate:

--- a/account_bank_statement_import_camt_oca/test_files/test-camt053-more-than-one-xml
+++ b/account_bank_statement_import_camt_oca/test_files/test-camt053-more-than-one-xml
@@ -1,0 +1,581 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>TESTBANK/NL/1420561226673</MsgId>
+            <CreDtTm>2014-01-06T16:20:26.673Z</CreDtTm>
+        </GrpHdr>
+        <Stmt>
+            <Id>1234Test/1</Id>
+            <LglSeqNb>2</LglSeqNb>
+            <CreDtTm>2014-01-06T16:20:26.673Z</CreDtTm>
+            <FrToDt>
+                <FrDtTm>2014-01-05T00:00:00.000Z</FrDtTm>
+                <ToDtTm>2014-01-05T23:59:59.999Z</ToDtTm>
+            </FrToDt>
+            <Acct>
+                <Id>
+                    <IBAN>NL77ABNA0574908765</IBAN>
+                </Id>
+                <Nm>Example company</Nm>
+                <Svcr>
+                    <FinInstnId>
+                        <BIC>ABNANL2A</BIC>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">15568.27</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-01-05</Dt>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">15121.12</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-01-05</Dt>
+                </Dt>
+            </Bal>
+            <Ntry>
+                <Amt Ccy="EUR">754.25</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-01-05</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2014-01-05</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>RDDT</Cd>
+                            <SubFmlyCd>ESDD</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                    <Prtry>
+                        <Cd>EI</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <InstrId>INNDNL2U20141231000142300002844</InstrId>
+                            <EndToEndId>435005714488-ABNO33052620</EndToEndId>
+                            <MndtId>1880000341866</MndtId>
+                        </Refs>
+                        <AmtDtls>
+                            <TxAmt>
+                                <Amt Ccy="EUR">754.25</Amt>
+                            </TxAmt>
+                        </AmtDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Nm>INSURANCE COMPANY TESTX</Nm>
+                                <PstlAdr>
+                                    <StrtNm>TEST STREET 20</StrtNm>
+                                    <TwnNm>1234 AB TESTCITY</TwnNm>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>NL46ABNA0499998748</IBAN>
+                                </Id>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RltdAgts>
+                            <CdtrAgt>
+                                <FinInstnId>
+                                    <BIC>ABNANL2A</BIC>
+                                </FinInstnId>
+                            </CdtrAgt>
+                        </RltdAgts>
+                        <RmtInf>
+                            <Ustrd>Insurance policy 857239PERIOD 01.01.2014 - 31.12.2014</Ustrd>
+                        </RmtInf>
+                        <AddtlTxInf>MKB Insurance 859239PERIOD 01.01.2014 - 31.12.2014</AddtlTxInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+            <Ntry>
+                <Amt Ccy="EUR">664.05</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <RvslInd>true</RvslInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-01-05</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2014-01-05</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>IDDT</Cd>
+                            <SubFmlyCd>UPDD</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                    <Prtry>
+                        <Cd>EIST</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <Btch>
+                        <MsgId>2014/125</MsgId>
+                        <PmtInfId>2018/125-20141229-NORM</PmtInfId>
+                        <NbOfTxs>2</NbOfTxs>
+                        <TtlAmt Ccy="EUR">664.05</TtlAmt>
+                        <CdtDbtInd>DBIT</CdtDbtInd>
+                    </Btch>
+                    <TxDtls>
+                        <Refs>
+                            <InstrId>TESTBANK/NL/20141229/01206408</InstrId>
+                            <EndToEndId>TESTBANK/NL/20141229/01206408</EndToEndId>
+                            <MndtId>NL22ZZZ524885430000-C0125.1</MndtId>
+                        </Refs>
+                        <AmtDtls>
+                            <TxAmt>
+                                <Amt Ccy="EUR">564.05</Amt>
+                            </TxAmt>
+                        </AmtDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Nm>Test Customer</Nm>
+                                <PstlAdr>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>NL46ABNA0499998748</IBAN>
+                                </Id>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RltdAgts>
+                            <CdtrAgt>
+                                <FinInstnId>
+                                    <BIC>ABNANL2A</BIC>
+                                </FinInstnId>
+                            </CdtrAgt>
+                        </RltdAgts>
+                        <RmtInf>
+                            <Ustrd>Direct Debit S14 0410</Ustrd>
+                        </RmtInf>
+                        <RtrInf>
+                            <Rsn>
+                                <Cd>AC06</Cd>
+                            </Rsn>
+                        </RtrInf>
+                        <AddtlTxInf>Direct debit S14 0410 AC07 Rek.nummer blokkade TESTBANK/NL/20141229/01206408</AddtlTxInf>
+                    </TxDtls>
+                    <TxDtls>
+                        <Refs>
+                            <InstrId>TESTBANK/NL/20141229/01206407</InstrId>
+                            <EndToEndId>TESTBANK/NL/20141229/01206407</EndToEndId>
+                            <MndtId>NL22ZZZ524885430000-C0125.2</MndtId>
+                        </Refs>
+                        <AmtDtls>
+                            <TxAmt>
+                                <Amt Ccy="EUR">100.00</Amt>
+                            </TxAmt>
+                        </AmtDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Nm>Test Customer</Nm>
+                                <PstlAdr>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>NL46ABNA0499998748</IBAN>
+                                </Id>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RltdAgts>
+                            <CdtrAgt>
+                                <FinInstnId>
+                                    <BIC>ABNANL2A</BIC>
+                                </FinInstnId>
+                            </CdtrAgt>
+                        </RltdAgts>
+                        <RmtInf>
+                            <Ustrd>Direct Debit S14 0410</Ustrd>
+                        </RmtInf>
+                        <RtrInf>
+                            <Rsn>
+                                <Cd>AC06</Cd>
+                            </Rsn>
+                        </RtrInf>
+                        <AddtlTxInf>Direct debit S14 0410 AC07 Rek.nummer blokkade TESTBANK/NL/20141229/01206408</AddtlTxInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+            <Ntry>
+                <Amt Ccy="EUR">1405.31</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-01-05</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2014-01-05</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>RCDT</Cd>
+                            <SubFmlyCd>ESCT</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                    <Prtry>
+                        <Cd>ET</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <InstrId>INNDNL2U20140105000217200000708</InstrId>
+                            <EndToEndId>115</EndToEndId>
+                        </Refs>
+                        <AmtDtls>
+                            <TxAmt>
+                                <Amt Ccy="EUR">1405.31</Amt>
+                            </TxAmt>
+                        </AmtDtls>
+                        <RltdPties>
+                            <Dbtr>
+                                <Nm>3rd party Media</Nm>
+                                <PstlAdr>
+                                    <StrtNm>SOMESTREET 570-A</StrtNm>
+                                    <TwnNm>1276 ML HOUSCITY</TwnNm>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>NL69ABNA0522123643</IBAN>
+                                </Id>
+                            </DbtrAcct>
+                        </RltdPties>
+                        <RltdAgts>
+                            <DbtrAgt>
+                                <FinInstnId>
+                                    <BIC>ABNANL2A</BIC>
+                                </FinInstnId>
+                            </DbtrAgt>
+                        </RltdAgts>
+                        <AddtlTxInf>#RD PARTY MEDIA CUSNO 90782 4210773</AddtlTxInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>
+
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>TESTBANK/NL/1420561226673</MsgId>
+            <CreDtTm>2014-01-06T16:20:26.673Z</CreDtTm>
+        </GrpHdr>
+        <Stmt>
+            <Id>1234Test/1</Id>
+            <LglSeqNb>2</LglSeqNb>
+            <CreDtTm>2014-01-06T16:20:26.673Z</CreDtTm>
+            <FrToDt>
+                <FrDtTm>2014-01-05T00:00:00.000Z</FrDtTm>
+                <ToDtTm>2014-01-05T23:59:59.999Z</ToDtTm>
+            </FrToDt>
+            <Acct>
+                <Id>
+                    <IBAN>NL77ABNA0574908765</IBAN>
+                </Id>
+                <Nm>Example company</Nm>
+                <Svcr>
+                    <FinInstnId>
+                        <BIC>ABNANL2A</BIC>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">15568.27</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-01-05</Dt>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">15121.12</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>2014-01-05</Dt>
+                </Dt>
+            </Bal>
+            <Ntry>
+                <Amt Ccy="EUR">754.25</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-01-05</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2014-01-05</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>RDDT</Cd>
+                            <SubFmlyCd>ESDD</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                    <Prtry>
+                        <Cd>EI</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <InstrId>INNDNL2U20141231000142300002844</InstrId>
+                            <EndToEndId>435005714488-ABNO33052620</EndToEndId>
+                            <MndtId>1880000341866</MndtId>
+                        </Refs>
+                        <AmtDtls>
+                            <TxAmt>
+                                <Amt Ccy="EUR">754.25</Amt>
+                            </TxAmt>
+                        </AmtDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Nm>INSURANCE COMPANY TESTX</Nm>
+                                <PstlAdr>
+                                    <StrtNm>TEST STREET 20</StrtNm>
+                                    <TwnNm>1234 AB TESTCITY</TwnNm>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>NL46ABNA0499998748</IBAN>
+                                </Id>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RltdAgts>
+                            <CdtrAgt>
+                                <FinInstnId>
+                                    <BIC>ABNANL2A</BIC>
+                                </FinInstnId>
+                            </CdtrAgt>
+                        </RltdAgts>
+                        <RmtInf>
+                            <Ustrd>Insurance policy 857239PERIOD 01.01.2014 - 31.12.2014</Ustrd>
+                        </RmtInf>
+                        <AddtlTxInf>MKB Insurance 859239PERIOD 01.01.2014 - 31.12.2014</AddtlTxInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+            <Ntry>
+                <Amt Ccy="EUR">664.05</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <RvslInd>true</RvslInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-01-05</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2014-01-05</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>IDDT</Cd>
+                            <SubFmlyCd>UPDD</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                    <Prtry>
+                        <Cd>EIST</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <Btch>
+                        <MsgId>2014/125</MsgId>
+                        <PmtInfId>2018/125-20141229-NORM</PmtInfId>
+                        <NbOfTxs>2</NbOfTxs>
+                        <TtlAmt Ccy="EUR">664.05</TtlAmt>
+                        <CdtDbtInd>DBIT</CdtDbtInd>
+                    </Btch>
+                    <TxDtls>
+                        <Refs>
+                            <InstrId>TESTBANK/NL/20141229/01206408</InstrId>
+                            <EndToEndId>TESTBANK/NL/20141229/01206408</EndToEndId>
+                            <MndtId>NL22ZZZ524885430000-C0125.1</MndtId>
+                        </Refs>
+                        <AmtDtls>
+                            <TxAmt>
+                                <Amt Ccy="EUR">564.05</Amt>
+                            </TxAmt>
+                        </AmtDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Nm>Test Customer</Nm>
+                                <PstlAdr>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>NL46ABNA0499998748</IBAN>
+                                </Id>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RltdAgts>
+                            <CdtrAgt>
+                                <FinInstnId>
+                                    <BIC>ABNANL2A</BIC>
+                                </FinInstnId>
+                            </CdtrAgt>
+                        </RltdAgts>
+                        <RmtInf>
+                            <Ustrd>Direct Debit S14 0410</Ustrd>
+                        </RmtInf>
+                        <RtrInf>
+                            <Rsn>
+                                <Cd>AC06</Cd>
+                            </Rsn>
+                        </RtrInf>
+                        <AddtlTxInf>Direct debit S14 0410 AC07 Rek.nummer blokkade TESTBANK/NL/20141229/01206408</AddtlTxInf>
+                    </TxDtls>
+                    <TxDtls>
+                        <Refs>
+                            <InstrId>TESTBANK/NL/20141229/01206407</InstrId>
+                            <EndToEndId>TESTBANK/NL/20141229/01206407</EndToEndId>
+                            <MndtId>NL22ZZZ524885430000-C0125.2</MndtId>
+                        </Refs>
+                        <AmtDtls>
+                            <TxAmt>
+                                <Amt Ccy="EUR">100.00</Amt>
+                            </TxAmt>
+                        </AmtDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Nm>Test Customer</Nm>
+                                <PstlAdr>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                            </Cdtr>
+                            <CdtrAcct>
+                                <Id>
+                                    <IBAN>NL46ABNA0499998748</IBAN>
+                                </Id>
+                            </CdtrAcct>
+                        </RltdPties>
+                        <RltdAgts>
+                            <CdtrAgt>
+                                <FinInstnId>
+                                    <BIC>ABNANL2A</BIC>
+                                </FinInstnId>
+                            </CdtrAgt>
+                        </RltdAgts>
+                        <RmtInf>
+                            <Ustrd>Direct Debit S14 0410</Ustrd>
+                        </RmtInf>
+                        <RtrInf>
+                            <Rsn>
+                                <Cd>AC06</Cd>
+                            </Rsn>
+                        </RtrInf>
+                        <AddtlTxInf>Direct debit S14 0410 AC07 Rek.nummer blokkade TESTBANK/NL/20141229/01206408</AddtlTxInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+            <Ntry>
+                <Amt Ccy="EUR">1405.31</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>2014-01-05</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>2014-01-05</Dt>
+                </ValDt>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            <Cd>RCDT</Cd>
+                            <SubFmlyCd>ESCT</SubFmlyCd>
+                        </Fmly>
+                    </Domn>
+                    <Prtry>
+                        <Cd>ET</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <Refs>
+                            <InstrId>INNDNL2U20140105000217200000708</InstrId>
+                            <EndToEndId>115</EndToEndId>
+                        </Refs>
+                        <AmtDtls>
+                            <TxAmt>
+                                <Amt Ccy="EUR">1405.31</Amt>
+                            </TxAmt>
+                        </AmtDtls>
+                        <RltdPties>
+                            <Dbtr>
+                                <Nm>3rd party Media</Nm>
+                                <PstlAdr>
+                                    <StrtNm>SOMESTREET 570-A</StrtNm>
+                                    <TwnNm>1276 ML HOUSCITY</TwnNm>
+                                    <Ctry>NL</Ctry>
+                                </PstlAdr>
+                            </Dbtr>
+                            <DbtrAcct>
+                                <Id>
+                                    <IBAN>NL69ABNA0522123643</IBAN>
+                                </Id>
+                            </DbtrAcct>
+                        </RltdPties>
+                        <RltdAgts>
+                            <DbtrAgt>
+                                <FinInstnId>
+                                    <BIC>ABNANL2A</BIC>
+                                </FinInstnId>
+                            </DbtrAgt>
+                        </RltdAgts>
+                        <AddtlTxInf>#RD PARTY MEDIA CUSNO 90782 4210773</AddtlTxInf>
+                    </TxDtls>
+                </NtryDtls>
+            </Ntry>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>


### PR DESCRIPTION
This PR propose a fix for the issue #209.

With this PR:

- Consider the bank account number related to the bank journal on which the file is imported. all statements for other account numbers are ignored.
- Consider the currency related to the bank journal on which the file is imported. all statements in a different currencies are ignored.
- Consider the same use cases when the zip file contain files with statements on different bank account numbers or currencies.
- Manage the case when the CAMT file contains more that one document. (Known issue in BNP France CAMT files)