### PR TITLE
[FIX][9.0] balance calculation inverted on ofx import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ sudo: false
 cache: pip
 
 addons:
+  # By default postgresql-9.1 is installed but there is issue related:
+  #  https://github.com/OCA/maintainer-quality-tools/issues/432#issuecomment-281580935
+  # Better use higher PostgreSQL version
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
+++ b/account_bank_statement_import_ofx/account_bank_statement_import_ofx.py
@@ -70,9 +70,9 @@ class AccountBankStatementImport(models.TransientModel):
         vals_bank_statement = {
             'name': ofx.account.routing_number,
             'transactions': transactions,
-            'balance_start': ofx.account.statement.balance,
-            'balance_end_real':
-                float(ofx.account.statement.balance) + total_amt,
+            'balance_start': 
+                float(ofx.account.statement.balance) - total_amt,
+            'balance_end_real': ofx.account.statement.balance,
         }
         return ofx.account.statement.currency, ofx.account.number, [
             vals_bank_statement]

--- a/account_bank_statement_import_ofx/tests/test_import_bank_statement.py
+++ b/account_bank_statement_import_ofx/tests/test_import_bank_statement.py
@@ -23,8 +23,8 @@ class TestOfxFile(TransactionCase):
         bank_statement.import_file()
         bank_st_record = self.bank_statement_model.search(
             [('name', '=', '000000123')])[0]
-        self.assertEquals(bank_st_record.balance_start, 2156.56)
-        self.assertEquals(bank_st_record.balance_end_real, 1796.56)
+        self.assertEquals(bank_st_record.balance_start, 1796.56)
+        self.assertEquals(bank_st_record.balance_end_real, 2156.56)
 
         line = bank_st_record.line_ids[0]
         self.assertEquals(line.name, 'Agrolait')


### PR DESCRIPTION
Start and end balance for imported statement were incorrectly calculated

Balance retrieved from ofx file is the the final one. You cet the starting zone by removing transactions from final balance.
Note : this is also alignment with the behaviour of this module in v10.0 onwards