### PR TITLE
[11.0] Don't update the field "name" of the transaction when parsing transaction details.

### DIFF
--- a/account_bank_statement_import_camt_oca/models/parser.py
+++ b/account_bank_statement_import_camt_oca/models/parser.py
@@ -54,12 +54,13 @@ class CamtParser(models.AbstractModel):
     def parse_transaction_details(self, ns, node, transaction):
         """Parse TxDtls node."""
         # message
-        self.add_value_from_node(
-            ns, node, [
-                './ns:RmtInf/ns:Ustrd|./ns:RtrInf/ns:AddtlInf',
-                './ns:AddtlNtryInf',
-                './ns:Refs/ns:InstrId',
-            ], transaction, 'name', join_str='\n')
+        if transaction['name'] == '/':
+            self.add_value_from_node(
+                ns, node, [
+                    './ns:RmtInf/ns:Ustrd|./ns:RtrInf/ns:AddtlInf',
+                    './ns:AddtlNtryInf',
+                    './ns:Refs/ns:InstrId',
+                ], transaction, 'name', join_str='\n')
         # name
         self.add_value_from_node(
             ns, node, [


### PR DESCRIPTION
If the field "name" of the module "account.bank.statement.line" is already assigned (AddtlNtryInf) during the parse of the tansaction details (Ntry/NtryDtls) element of the camt file, to avoid to lose data, we should not update it.