### PR TITLE
[12.0][IMP] use addres when no partner

### DIFF
--- a/account_bank_statement_import_camt_oca/models/parser.py
+++ b/account_bank_statement_import_camt_oca/models/parser.py
@@ -86,8 +86,16 @@ class CamtParser(models.AbstractModel):
         party_node = node.xpath(
             './ns:RltdPties/ns:%s' % party_type, namespaces={'ns': ns})
         if party_node:
-            self.add_value_from_node(
-                ns, party_node[0], './ns:Nm', transaction, 'partner_name')
+            name_node = node.xpath(
+                './ns:RltdPties/ns:%s/ns:Nm' % party_type,
+                namespaces={'ns': ns})
+            if name_node:
+                self.add_value_from_node(
+                    ns, party_node[0], './ns:Nm', transaction, 'partner_name')
+            else:
+                self.add_value_from_node(
+                    ns, party_node[0], './ns:PstlAdr/ns:AdrLine',
+                    transaction, 'partner_name')
         # Get remote_account from iban or from domestic account:
         account_node = node.xpath(
             './ns:RltdPties/ns:%sAcct/ns:Id' % party_type,


### PR DESCRIPTION
when no partner_name send in bank statement address can be used
for partner identification