### PR TITLE
[10.0][FIX] prevent assigning parner with default name

### DIFF
--- a/account_bank_statement_import_camt/models/__init__.py
+++ b/account_bank_statement_import_camt/models/__init__.py
@@ -3,3 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import parser
 from . import account_bank_statement_import
+from . import bank_statement
+from . import account_bank_statement_line

--- a/account_bank_statement_import_camt/models/account_bank_statement_line.py
+++ b/account_bank_statement_import_camt/models/account_bank_statement_line.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class AccountBankStatementLine(models.Model):
+
+    _inherit = "account.bank.statement.line"
+
+    @api.multi
+    def write(self, vals):
+        """
+        Purpose of this hook is catch updates for records with name == '/'
+
+        In reconciliation_widget_preprocess, there is attempt to assign
+        partner into statement line, this assignment relies on name,
+        during import name setup to '/' for records without it
+        and this makes search results wrong and partner assignment randomly
+        """
+        if (
+            self.env.context.get('no_reassign_empty_name')
+            and len(self) == 1
+            and len(vals.keys()) == 1
+            and 'partner_id' in vals
+            and self.name == '/'
+        ):
+            return True
+        return super(AccountBankStatementLine, self).write(vals)

--- a/account_bank_statement_import_camt/models/bank_statement.py
+++ b/account_bank_statement_import_camt/models/bank_statement.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class AccountBankStatement(models.Model):
+
+    _inherit = "account.bank.statement"
+
+    @api.multi
+    def reconciliation_widget_preprocess(self):
+        return super(AccountBankStatement, self.with_context(
+            no_reassign_empty_name=True)).reconciliation_widget_preprocess()

--- a/account_bank_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_bank_statement_import_camt/tests/test_import_bank_statement.py
@@ -31,7 +31,7 @@ class TestParser(TransactionCase):
                 temp.seek(0)
                 diff = list(
                     difflib.unified_diff(golden.readlines(), temp.readlines(),
-                                         golden.name,        temp.name))
+                                         golden.name, temp.name))
                 if len(diff) > 2:
                     self.fail(
                         "actual output doesn't match exptected output:\n%s" %


### PR DESCRIPTION
if statement has entries with empty ref (which assign to '/' in odoo) reconciliation widget cannot properly find partner_id, this PR prevents such assignment so user will see initial name given by statement