### PR TITLE
[10.0] account_bank_statement_import_camt: Fix error in currencies

### DIFF
--- a/account_bank_statement_import_camt/__manifest__.py
+++ b/account_bank_statement_import_camt/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'CAMT Format Bank Statements Import',
-    'version': '10.0.1.1.6',
+    'version': '10.0.1.1.7',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Therp BV',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_camt/test_files/golden-camt053-txdtls.pydata
+++ b/account_bank_statement_import_camt/test_files/golden-camt053-txdtls.pydata
@@ -1,4 +1,4 @@
-(None,
+('CHF',
  'CH1111000000123456789',
  [{'balance_end_real': 79443.15,
    'balance_start': 75960.15,

--- a/account_bank_statement_import_camt/test_files/golden-camt053-txdtls.pydata
+++ b/account_bank_statement_import_camt/test_files/golden-camt053-txdtls.pydata
@@ -15,4 +15,8 @@
                      'date': '2017-03-22',
                      'name': u'CR\xc9DIT GROUP\xc9 BVR TRAITEMENT DU 22.03.2017 NUM\xc9RO CLIENT 01-70884-3 PAQUET ID: 123456CHCAFEBABE',
                      'partner_name': 'Banque Cantonale Vaudoise',
-                     'ref': '302388292000022222222222222'}]}])
+                     'ref': '302388292000022222222222222'},
+                    {'amount': -4220.21,
+                     'date': '2017-03-22',
+                     'name': '/',
+                     'ref': '20170323001234567891234567891234'}]}])

--- a/account_bank_statement_import_camt/test_files/test-camt053-txdtls
+++ b/account_bank_statement_import_camt/test_files/test-camt053-txdtls
@@ -25,6 +25,7 @@
         <Ownr>
           <Nm>Open Net S. à r.l. Prilly</Nm>
         </Ownr>
+        <Ccy>CHF</Ccy>
       </Acct>
       <Bal>
         <Tp>
@@ -208,6 +209,121 @@
           </TxDtls>
         </NtryDtls>
         <AddtlNtryInf>CRÉDIT GROUPÉ BVR TRAITEMENT DU 22.03.2017 NUMÉRO CLIENT 01-70884-3 PAQUET ID: 123456CHCAFEBABE</AddtlNtryInf>
+      </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">4220.21</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>BOOK</Sts>
+        <BookgDt>
+          <Dt>2017-03-22</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2017-03-23</Dt>
+        </ValDt>
+        <AcctSvcrRef>20170323001234567891234567891234</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>ICDT</Cd>
+              <SubFmlyCd>XBCT</SubFmlyCd>
+            </Fmly>
+          </Domn>
+        </BkTxCd>
+        <AmtDtls>
+          <InstdAmt>
+            <Amt Ccy="GBP">3294.00</Amt>
+          </InstdAmt>
+          <TxAmt>
+            <Amt Ccy="GBP">3294.00</Amt>
+          </TxAmt>
+          <CntrValAmt>
+            <Amt Ccy="CHF">4220.21000</Amt>
+            <CcyXchg>
+              <SrcCcy>GBP</SrcCcy>
+              <TrgtCcy>CHF</TrgtCcy>
+              <XchgRate>1.28118</XchgRate>
+              <QtnDt>2017-03-23T00:00:00.000+02:00</QtnDt>
+            </CcyXchg>
+          </CntrValAmt>
+        </AmtDtls>
+        <Chrgs>
+          <TtlChrgsAndTaxAmt Ccy="CHF">29.000</TtlChrgsAndTaxAmt>
+          <Rcrd>
+            <Amt Ccy="CHF">5.000</Amt>
+            <CdtDbtInd>DBIT</CdtDbtInd>
+            <ChrgInclInd>false</ChrgInclInd>
+            <Tp>
+              <Prtry>
+                <Id>INTERNAL</Id>
+              </Prtry>
+            </Tp>
+          </Rcrd>
+          <Rcrd>
+            <Amt Ccy="CHF">24.000</Amt>
+            <CdtDbtInd>DBIT</CdtDbtInd>
+            <ChrgInclInd>false</ChrgInclInd>
+            <Tp>
+              <Prtry>
+                <Id>EXTERNAL</Id>
+              </Prtry>
+            </Tp>
+          </Rcrd>
+        </Chrgs>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>20170323001234567891234567891234</AcctSvcrRef>
+              <Prtry>
+                <Tp>01</Tp>
+                <Ref>20170323001234567891234567891234</Ref>
+              </Prtry>
+            </Refs>
+            <Amt Ccy="GBP">3294.00000</Amt>
+            <CdtDbtInd>DBIT</CdtDbtInd>
+            <RltdPties>
+              <Cdtr>
+                <Nm>POSTFINANCE AG</Nm>
+                <PstlAdr>
+                  <AdrLine>MINGERSTRASSE 20</AdrLine>
+                  <AdrLine>3030 BERNE</AdrLine>
+                </PstlAdr>
+              </Cdtr>
+              <CdtrAcct>
+                <Id>
+                  <IBAN>CH3333000000123456789</IBAN>
+                </Id>
+              </CdtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <CdtrAgt>
+                <FinInstnId>
+                  <Nm>Banque Cantonale Vaudoise</Nm>
+                  <PstlAdr>
+                    <StrtNm>Place Saint-François</StrtNm>
+                    <BldgNb>14</BldgNb>
+                    <PstCd>1003</PstCd>
+                    <TwnNm>Lausanne</TwnNm>
+                    <Ctry>CH1</Ctry>
+                  </PstlAdr>
+                </FinInstnId>
+              </CdtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Prtry>ISR Reference</Prtry>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>302388292000033333333333333</Ref>
+                </CdtrRefInf>
+                <AddtlRmtInf>?REJECT?0</AddtlRmtInf>
+              </Strd>
+            </RmtInf>
+          </TxDtls>
+        </NtryDtls>
       </Ntry>
     </Stmt>
   </BkToCstmrStmt>


### PR DESCRIPTION
In the case of a multi currencies CAMT import, the currency set on the payment line will be the currency of the account but the amount is in the foreign currency. This happens because in the node `TxDtls` it is optional to have the conversion information used during the transaction, hence the currency does not match the one set on the account.
The only workaround I found for this case is to skip the parsing of the `TxDtls` node if the currencies does not match between account and transaction. The payment line will need to be manually processed in the GUI after the import.