### PR TITLE
IMP acc_bank_stat_imp_ofx: add checknum in name when required

### DIFF
--- a/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
+++ b/account_bank_statement_import_ofx/wizard/account_bank_statement_import.py
@@ -53,10 +53,14 @@ class AccountBankStatementImport(models.TransientModel):
         # If you read odoo10/addons/account_bank_statement_import/
         # account_bank_statement_import.py, it's the only 2 keys
         # we can provide to match a partner.
+        name = transaction.payee
+        if transaction.checknum:
+            name += " " + transaction.checknum
+        if transaction.memo:
+            name += " : " + transaction.memo
         vals = {
             'date': transaction.date,
-            'name': transaction.payee + (
-                transaction.memo and ': ' + transaction.memo or ''),
+            'name': name,
             'ref': transaction.id,
             'amount': float(transaction.amount),
             'unique_import_id': transaction.id,


### PR DESCRIPTION
OFX format include checknum describing check number. Some banks add this number in memo attribute, but other only display it adhoc attribute.

With this fix, this number will appear on the Odoo widget reconciliation.

Please could you have a look on this PR @llacroix @remi-filament ? Thanks

