### PR TITLE
Add line for original name from camt

### DIFF
--- a/account_bank_statement_import_camt_details/__manifest__.py
+++ b/account_bank_statement_import_camt_details/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'CAMT Debitor Details Bank Statements Import',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'license': 'AGPL-3',
     'author': 'Odoo Community Association (OCA), Compassion CH',
     'website': 'https://github.com/OCA/bank-statement-import',

--- a/account_bank_statement_import_camt_details/models/account_bank_statement_line.py
+++ b/account_bank_statement_import_camt_details/models/account_bank_statement_line.py
@@ -19,6 +19,9 @@ class AccountBankStatementLine(models.Model):
         """
         data = super(AccountBankStatementLine,
                      self).get_statement_line_for_reconciliation_widget()
+        if self.partner_name:
+            data['partner_name_camt'] = self.partner_name
+
         if self.partner_address:
             data['partner_address'] = self.partner_address
         if self.partner_account:

--- a/account_bank_statement_import_camt_details/static/src/xml/camt_details_reconciliation_layout.xml
+++ b/account_bank_statement_import_camt_details/static/src/xml/camt_details_reconciliation_layout.xml
@@ -3,6 +3,7 @@
   <t t-extend="bank_statement_reconciliation_statement_line_details">
     
     <t t-jquery="table.details > tr:nth-child(2)" t-operation="after">
+        <tr t-if="line.partner_name_camt"><td>Camt Name</td><td><t t-esc="line.partner_name_camt"/></td></tr>
         <tr t-if="line.partner_address"><td>Address</td><td><t t-esc="line.partner_address"/></td></tr>
     </t>
       <t t-jquery="table.details > tr:nth-child(6)" t-operation="after">


### PR DESCRIPTION
Adds a line for the original name from the camt in the information box.
The current one is sometimes omitted and this also allows to check the selected partners name against the original one.