### PR TITLE
11.0 skip mapping currency line with wrong sign

### DIFF
--- a/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_map.py
+++ b/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_map.py
@@ -103,6 +103,7 @@ class AccountBankStatementImportPaypalMapLIne(models.Model):
         selection=[
             ('%d/%m/%Y', 'i.e. 15/12/2019'),
             ('%m/%d/%Y', 'i.e. 12/15/2019'),
+            ('%d.%m.%Y', 'i.e. 15.12.2019')
         ],
         string="Date Format",
     )

--- a/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py
+++ b/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py
@@ -156,7 +156,7 @@ class AccountBankStatementImport(models.TransientModel):
             # transaction of currency change if yes merge the transaction
             # as for odoo it's only one line
             cline = currency_change_lines.get(line['origin_transaction_id'])
-            if cline and (cline['amount'] * line['amount'] > 0):
+            if cline:
                 # we update the current line with currency information
                 vals = self._prepare_paypal_currency_vals(cline)
                 line.update(vals)

--- a/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py
+++ b/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal.py
@@ -156,7 +156,7 @@ class AccountBankStatementImport(models.TransientModel):
             # transaction of currency change if yes merge the transaction
             # as for odoo it's only one line
             cline = currency_change_lines.get(line['origin_transaction_id'])
-            if cline:
+            if cline and (cline['amount'] * line['amount'] > 0):
                 # we update the current line with currency information
                 vals = self._prepare_paypal_currency_vals(cline)
                 line.update(vals)


### PR DESCRIPTION
At Paypal Bank Statement Import we have to check that the related currency line has got the same sign than the original transaction.

I have attachted an original paypal file here (anonymized), where the import fails, because the import would create two exact lines with the same unique_import_id, and it would map a positive value with a negative value.

For checking the file you have to use the German Paypal Format, which I have added here to:


[CustomSTMT2020_Anonymized_German_Format.CSV.txt](https://github.com/OCA/bank-statement-import/files/4090140/CustomSTMT2020_Anonymized_German_Format.CSV.txt)
[account.bank.statement.import.paypal.map.csv.txt](https://github.com/OCA/bank-statement-import/files/4090142/account.bank.statement.import.paypal.map.csv.txt)
