### PR TITLE
[12.0][IMP] - Add an option to group payment return at camt statements import

### DIFF
--- a/account_bank_statement_import_camt_oca/__manifest__.py
+++ b/account_bank_statement_import_camt_oca/__manifest__.py
@@ -12,5 +12,6 @@
     ],
     'data': [
         'views/account_bank_statement_import.xml',
+        'views/account_journal.xml',
     ],
 }

--- a/account_bank_statement_import_camt_oca/models/account_journal.py
+++ b/account_bank_statement_import_camt_oca/models/account_journal.py
@@ -1,11 +1,15 @@
 # Copyright 2019 ACSONE SA/NV <thomas.binsfeld@acsone.eu>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models, _
+from odoo import fields, models, _
 
 
 class AccountJournal(models.Model):
     _inherit = "account.journal"
+
+    group_return_statement_at_camt_import = fields.Boolean(
+        string="Group Return Statements At CAMT Import"
+    )
 
     def _get_bank_statements_available_import_formats(self):
         res = super(AccountJournal, self).\

--- a/account_bank_statement_import_camt_oca/models/parser.py
+++ b/account_bank_statement_import_camt_oca/models/parser.py
@@ -130,6 +130,14 @@ class CamtParser(models.AbstractModel):
             ],
             transaction, 'ref'
         )
+        if self.env.context.get('journal_id'):
+            journal = self.env['account.journal'].browse(
+                self.env.context.get('journal_id')
+            )
+            if journal.group_return_statement_at_camt_import:
+                if amount < 0:
+                    yield transaction
+                    return
 
         details_nodes = node.xpath(
             './ns:NtryDtls/ns:TxDtls', namespaces={'ns': ns})

--- a/account_bank_statement_import_camt_oca/views/account_journal.xml
+++ b/account_bank_statement_import_camt_oca/views/account_journal.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_account_journal_form" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='currency_id']" position="after">
+                <field name="group_return_statement_at_camt_import"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When importing bank statements, all payment return transactions are imported individually.

To improve the reconciliation performance, it's better to have an option to group all payment return in a one transaction.

Todo:
- [ ] Add unit tests