### PR TITLE
[12.0][FIX] account_bank_statement_import_online_paypal: workaround for PayPal issue

### DIFF
--- a/account_bank_statement_import_online_paypal/readme/ROADMAP.rst
+++ b/account_bank_statement_import_online_paypal/readme/ROADMAP.rst
@@ -5,3 +5,7 @@
 * `PayPal Transaction Info <https://developer.paypal.com/docs/api/sync/v1/#definition-transaction_info>`_
   defines extra fields like ``tip_amount``, ``shipping_amount``, etc. that
   could be useful to be decomposed from a single transaction.
+* There's a known issue with PayPal API that on every Monday for couple of
+  hours after UTC midnight it returns ``INVALID_REQUEST`` incorrectly: their
+  servers have not inflated the data yet. PayPal tech support confirmed this
+  behaviour in case #06650320 (private).


### PR DESCRIPTION
There's a known issue with PayPal API that on every Monday for couple of hours after UTC midnight it returns `INVALID_REQUEST` incorrectly: their servers have not inflated the data yet. PayPal tech support confirmed this behaviour in case 06650320 (private).
