### PR TITLE
[12.0][account_bank_statement_import_txt_xlsx] fix error parsing field 'original_amount'

### DIFF
--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
@@ -220,7 +220,10 @@ class AccountBankStatementImportSheetParser(models.TransientModel):
             elif original_currency == currency:
                 original_amount = amount
 
-            original_amount = self._parse_decimal(original_amount, mapping)
+            if original_amount is not None:
+                original_amount = self._parse_decimal(original_amount, mapping)
+            else:
+                original_amount = 0.0
 
             line = {
                 'timestamp': timestamp,


### PR DESCRIPTION
At this moment it is not possible to leave the field 'original_amount' excluded from the mapping. It attempts to parse to a decimal a null value.

