### PR TITLE
[12.0] Deeply wrong dependencies specification for `account_bank_statement_import_txt_xlsx`

### DIFF
--- a/account_bank_statement_import_txt_xlsx/__manifest__.py
+++ b/account_bank_statement_import_txt_xlsx/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Account Bank Statement Import TXT XLSX",
     "summary": "Import TXT/CSV or XLSX files as Bank Statements in Odoo",
-    "version": "12.0.2.0.2",
+    "version": "12.0.2.0.3",
     "category": "Accounting",
     "website": "https://github.com/OCA/bank-statement-import",
     "author":
@@ -21,7 +21,6 @@
     ],
     "external_dependencies": {
         "python": [
-            "csv",
             "xlrd",
         ]
     },


### PR DESCRIPTION
Hello, @alexey-pelykh.
Hello, everyone.

We're trying to use the module named `account_bank_statement_import_txt_xlsx`.  
It works great when you download it and copy it directly where you need it!

**BUT...**  
Our technological stack includes `pipenv` as package manager for Odoo, its modules and its dependencies.

So...  
When we try to install this module (also using `pip`), it looks for a Python module named `csv` on the package indexes.  
Actually, it would be great if `csv` was a package you can really install but... You know... It is already included in Python's Standard Library and it's deeply wrong to include something that comes by default with the technology you're using.

Here the commit involved: https://github.com/OCA/bank-statement-import/commit/a605bde5f533c55f954eae9199c15343265c010b#diff-1a406bafb14916f5c8fac3ea34cefaf6R24

---

This PR, simply, solves this problem.