### PR TITLE
[FIX] account_bank_statement_import_camt_oca: support DtTm and Dt

### DIFF
--- a/account_bank_statement_import_camt_oca/models/parser.py
+++ b/account_bank_statement_import_camt_oca/models/parser.py
@@ -129,7 +129,9 @@ class CamtParser(models.AbstractModel):
     def parse_entry(self, ns, node):
         """Parse an Ntry node and yield transactions"""
         transaction = {"name": "/", "amount": 0}  # fallback defaults
-        self.add_value_from_node(ns, node, "./ns:BookgDt/ns:Dt", transaction, "date")
+        self.add_value_from_node(
+            ns, node, "./ns:BookgDt/ns:Dt | ./ns:BookgDt/ns:DtTm", transaction, "date"
+        )
         amount = self.parse_amount(ns, node)
         if amount != 0.0:
             transaction["amount"] = amount


### PR DESCRIPTION
* Some banks use DtTm instead of Dt for dates