### PR TITLE
[12.0][FIX] account_bank_statement_import_txt_xlsx: handle empty currency

### DIFF
--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
@@ -206,22 +206,27 @@ class AccountBankStatementImportSheetParser(models.TransientModel):
                 )
 
             amount = self._parse_decimal(amount, mapping)
-            if balance is not None:
+            if balance:
                 balance = self._parse_decimal(balance, mapping)
+            else:
+                balance = None
 
-            if debit_credit is not None:
+            if debit_credit:
                 amount = amount.copy_abs()
                 if debit_credit == mapping.debit_value:
                     amount = -amount
 
-            if original_currency is None:
+            if not original_currency:
                 original_currency = currency
                 original_amount = amount
             elif original_currency == currency:
                 original_amount = amount
 
-            if original_amount is not None:
-                original_amount = self._parse_decimal(original_amount, mapping)
+            if original_amount:
+                original_amount = self._parse_decimal(
+                    original_amount,
+                    mapping
+                ).copy_sign(amount)
             else:
                 original_amount = 0.0
 

--- a/account_bank_statement_import_txt_xlsx/tests/fixtures/original_currency_empty.csv
+++ b/account_bank_statement_import_txt_xlsx/tests/fixtures/original_currency_empty.csv
@@ -1,2 +1,2 @@
 "Date","Label","Currency","Amount","Amount Currency","Partner Name","Bank Account"
-"12/15/2018","Your payment","EUR","1,525.00","-1,000.00","Azure Interior",""
+"12/15/2018","Your payment",,"1,525.00",,"Azure Interior",""


### PR DESCRIPTION
Currently if there's currency or amount column specified yet some lines have it empty (alike none), import fails