### PR TITLE
Proposition de tradustion française et correction de la vue "Ponto"

### DIFF
--- a/account_bank_statement_clear_partner/i18n/fr_FR.po
+++ b/account_bank_statement_clear_partner/i18n/fr_FR.po
@@ -1,0 +1,28 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_clear_partner
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_clear_partner
+#: model:ir.model,name:account_bank_statement_clear_partner.model_account_bank_statement
+msgid "Bank Statement"
+msgstr "Relevé bancaire"
+
+#. module: account_bank_statement_clear_partner
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_clear_partner.view_bank_statement_form
+msgid "Clear partners"
+msgstr "Effacer les partenaires"

--- a/account_bank_statement_import_ofx/i18n/fr_FR.po
+++ b/account_bank_statement_import_ofx/i18n/fr_FR.po
@@ -9,14 +9,15 @@ msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-04-11 21:55+0000\n"
-"PO-Revision-Date: 2017-04-11 21:55+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2016\n"
+"PO-Revision-Date: 2021-03-09 10:11+0100\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
 "Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #. module: account_bank_statement_import_ofx
 #: model:ir.model,name:account_bank_statement_import_ofx.model_account_bank_statement_import
@@ -26,7 +27,7 @@ msgstr "Importer Relevé Bancaire"
 #. module: account_bank_statement_import_ofx
 #: model:ir.model,name:account_bank_statement_import_ofx.model_account_journal
 msgid "Journal"
-msgstr ""
+msgstr "Journal"
 
 #. module: account_bank_statement_import_ofx
 #: model_terms:ir.ui.view,arch_db:account_bank_statement_import_ofx.view_account_bank_statement_import_form

--- a/account_bank_statement_import_online/i18n/fr_FR.po
+++ b/account_bank_statement_import_online/i18n/fr_FR.po
@@ -1,0 +1,491 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_import_online
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_import_online
+#: code:addons/account_bank_statement_import_online/models/online_bank_statement_provider.py:153
+#, python-format
+msgid "%(number)s %(type)s"
+msgstr "%(number)s %(type)s"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_needaction
+msgid "Action Needed"
+msgstr "Action requise"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__active
+msgid "Active"
+msgstr "Actif"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__api_base
+msgid "Api Base"
+msgstr "API Base"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_attachment_count
+msgid "Attachment Count"
+msgstr "Nombre de pièces jointes"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_pull_wizard_form
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__certificate
+msgid "Certificate"
+msgstr "Certificat"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__certificate_chain
+msgid "Certificate Chain"
+msgstr "Chaîne de certificats"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__certificate_private_key
+msgid "Certificate Private Key"
+msgstr "Certificat Clé privée"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__certificate_public_key
+msgid "Certificate Public Key"
+msgstr "Certificat Clé publique"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__company_id
+msgid "Company"
+msgstr "Société"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__company_id
+msgid "Company related to this journal"
+msgstr "Société associée à ce journal"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_provider_form
+msgid "Configuration"
+msgstr "Configuration"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__create_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__create_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__currency_id
+msgid "Currency"
+msgstr "Devise"
+
+#. module: account_bank_statement_import_online
+#: selection:online.bank.statement.provider,statement_creation_mode:0
+msgid "Daily statements"
+msgstr "Relevés quotidiens"
+
+#. module: account_bank_statement_import_online
+#: selection:online.bank.statement.provider,interval_type:0
+msgid "Day(s)"
+msgstr "Jour(s)"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_provider_form
+msgid "Details"
+msgstr "Détails"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__display_name
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: account_bank_statement_import_online
+#: code:addons/account_bank_statement_import_online/models/online_bank_statement_provider.py:196
+#, python-format
+msgid ""
+"Failed to obtain statement data for period since %s until %s: %s. See server "
+"logs for more details."
+msgstr ""
+"N’a pas obtenu les données des relevés pendant la période du %s au %s: %s. "
+"Consultez les journaux de serveurs pour plus de détails."
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_follower_ids
+msgid "Followers"
+msgstr "Abonnés"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_channel_ids
+msgid "Followers (Channels)"
+msgstr "Abonnés (Canaux)"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_partner_ids
+msgid "Followers (Partners)"
+msgstr "Abonnés (Partenaires)"
+
+#. module: account_bank_statement_import_online
+#: selection:online.bank.statement.provider,interval_type:0
+msgid "Hour(s)"
+msgstr "Heure(s)"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__id
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__message_unread
+msgid "If checked new messages require your attention."
+msgstr "Si coché, de nouveaux messages demandent votre attention."
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr "Si coché, de nouveaux messages demandent votre attention."
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__message_has_error
+msgid "If checked, some messages have a delivery error."
+msgstr "Si actif, certains messages ont une erreur de livraison."
+
+#. module: account_bank_statement_import_online
+#: code:addons/account_bank_statement_import_online/models/online_bank_statement_provider.py:150
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_provider_filter
+#, python-format
+msgid "Inactive"
+msgstr "Inactive"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__interval_type
+msgid "Interval Type"
+msgstr "Type d'intervalle"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_is_follower
+msgid "Is Follower"
+msgstr "Est un abonné"
+
+#. module: account_bank_statement_import_online
+#: code:addons/account_bank_statement_import_online/models/online_bank_statement_provider.py:205
+#, python-format
+msgid "Issue with Online Bank Statement Provider"
+msgstr "Problème avec le fournisseur de relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model,name:account_bank_statement_import_online.model_account_journal
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__journal_id
+msgid "Journal"
+msgstr "Journal"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__key
+msgid "Key"
+msgstr "Clé"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider____last_update
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__write_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__write_uid
+msgid "Last Updated by"
+msgstr "Dernière modification par"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__write_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__last_successful_run
+msgid "Last successful pull"
+msgstr "Dernier import réussi"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_main_attachment_id
+msgid "Main Attachment"
+msgstr "Pièce jointe principale"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_has_error
+msgid "Message Delivery error"
+msgstr "Erreur d'envoi du message"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_ids
+msgid "Messages"
+msgstr "Messages"
+
+#. module: account_bank_statement_import_online
+#: selection:online.bank.statement.provider,interval_type:0
+msgid "Minute(s)"
+msgstr "Minute(s)"
+
+#. module: account_bank_statement_import_online
+#: selection:online.bank.statement.provider,statement_creation_mode:0
+msgid "Monthly statements"
+msgstr "Relevés mensuels"
+
+#. module: account_bank_statement_import_online
+#: code:addons/account_bank_statement_import_online/models/online_bank_statement_provider.py:203
+#, python-format
+msgid "N/A"
+msgstr "N/A"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__name
+msgid "Name"
+msgstr "Nom"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__next_run
+msgid "Next scheduled pull"
+msgstr "Prochain import prévu"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_needaction_counter
+msgid "Number of Actions"
+msgstr "Nombre d'actions"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_has_error_counter
+msgid "Number of error"
+msgstr "Nombre d'erreurs"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__message_needaction_counter
+msgid "Number of messages which requires an action"
+msgstr "Nombre de messages exigeant une action"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr "Nombre de messages avec des erreurs d'envoi"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__message_unread_counter
+msgid "Number of unread messages"
+msgstr "Nombre de messages non lus"
+
+#. module: account_bank_statement_import_online
+#: code:addons/account_bank_statement_import_online/models/account_journal.py:28
+#, python-format
+msgid "Online (OCA)"
+msgstr "En ligne"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model,name:account_bank_statement_import_online.model_online_bank_statement_provider
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_account_bank_statement_import_journal_creation__online_bank_statement_provider
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_account_journal__online_bank_statement_provider
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_provider_form
+msgid "Online Bank Statement Provider"
+msgstr "Fournisseur de relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_provider_filter
+msgid "Online Bank Statement Providers"
+msgstr "Fournisseurs de relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online
+#: code:addons/account_bank_statement_import_online/models/account_journal.py:90
+#: model:ir.model,name:account_bank_statement_import_online.model_online_bank_statement_pull_wizard
+#, python-format
+msgid "Online Bank Statement Pull Wizard"
+msgstr "Utilitaire d’import de relevé bancaire en ligne"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.view_account_bank_journal_form
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.view_account_journal_form
+msgid "Online Bank Statements (OCA)"
+msgstr "Relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online
+#: model:ir.actions.server,name:account_bank_statement_import_online.action_online_bank_statements_pull_wizard
+msgid "Online Bank Statements Pull Wizard"
+msgstr "Utilitaire d’import des relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online
+#: sql_constraint:online.bank.statement.provider:0
+msgid "Only one online banking statement provider per journal!"
+msgstr "Un seul fournisseur de relevé bancaire en ligne par journal!"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__origin
+msgid "Origin"
+msgstr "Origine"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__passphrase
+msgid "Passphrase"
+msgstr "Phrase secrète"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__password
+msgid "Password"
+msgstr "Mot de passe"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.view_account_bank_journal_form
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.view_account_journal_form
+msgid "Provider"
+msgstr "Fournisseur"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__provider_ids
+msgid "Providers"
+msgstr "Fournisseurs"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_pull_wizard_form
+msgid "Pull"
+msgstr "Tirer"
+
+#. module: account_bank_statement_import_online
+#: model:ir.actions.server,name:account_bank_statement_import_online.ir_cron_account_pull_online_bank_statements_ir_actions_server
+#: model:ir.cron,cron_name:account_bank_statement_import_online.ir_cron_account_pull_online_bank_statements
+#: model:ir.cron,name:account_bank_statement_import_online.ir_cron_account_pull_online_bank_statements
+msgid "Pull Online Bank Statements"
+msgstr "Import des relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__account_number
+msgid "Sanitized Account Number"
+msgstr "Numéro de compte désinfecté"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_provider_form
+msgid "Scheduled Pull"
+msgstr "Import planifié"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__interval_number
+msgid "Scheduled update interval"
+msgstr "Intervalle de mise à jour planifié"
+
+#. module: account_bank_statement_import_online
+#: sql_constraint:online.bank.statement.provider:0
+msgid "Scheduled update interval must be greater than zero!"
+msgstr "L’intervalle de mise à jour planifié doit être supérieur à zéro!"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__service
+msgid "Service"
+msgstr "Service"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__date_since
+msgid "Since"
+msgstr "Depuis"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_pull_wizard_form
+msgid "Since (at least)"
+msgstr "Depuis (au moins)"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__statement_creation_mode
+msgid "Statement Creation Mode"
+msgstr "Mode création des relevés"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_account_bank_statement_import_journal_creation__online_bank_statement_provider_id
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_account_journal__online_bank_statement_provider_id
+msgid "Statement Provider"
+msgstr "Fournisseur de relevés"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__currency_id
+msgid "The currency used to enter statement"
+msgstr "La devise utilisée pour entrer les relevés"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__tz
+msgid "Timezone"
+msgstr "Fuseau horaire"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__tz
+msgid ""
+"Timezone to convert transaction timestamps to prior being saved into a "
+"statement."
+msgstr ""
+"Fuseau horaire pour convertir les horodatages de transaction avant qu’ils "
+"soient enregistrés dans un relevé."
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_unread
+msgid "Unread Messages"
+msgstr "Messages non lus"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__message_unread_counter
+msgid "Unread Messages Counter"
+msgstr "Compteur de messages non lus"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_pull_wizard__date_until
+msgid "Until"
+msgstr "Jusqu'à"
+
+#. module: account_bank_statement_import_online
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online.online_bank_statement_pull_wizard_form
+msgid "Until (at least)"
+msgstr "Jusqu’à ce que (au moins)"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__update_schedule
+msgid "Update Schedule"
+msgstr "Mettre à jour les horaires"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__username
+msgid "Username"
+msgstr "Nom d’utilisateur"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,field_description:account_bank_statement_import_online.field_online_bank_statement_provider__website_message_ids
+msgid "Website Messages"
+msgstr "Messages du site web"
+
+#. module: account_bank_statement_import_online
+#: model:ir.model.fields,help:account_bank_statement_import_online.field_online_bank_statement_provider__website_message_ids
+msgid "Website communication history"
+msgstr "Historique de communication du site web"
+
+#. module: account_bank_statement_import_online
+#: selection:online.bank.statement.provider,interval_type:0
+msgid "Week(s)"
+msgstr "Semaine(s)"
+
+#. module: account_bank_statement_import_online
+#: selection:online.bank.statement.provider,statement_creation_mode:0
+msgid "Weekly statements"
+msgstr "Relevés hebdomadaires"

--- a/account_bank_statement_import_online_paypal/i18n/fr_FR.po
+++ b/account_bank_statement_import_online_paypal/i18n/fr_FR.po
@@ -6,617 +6,584 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-02 14:29+0100\n"
+"PO-Revision-Date: \n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
 "Language-Team: \n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
 "X-Generator: Poedit 2.4.2\n"
-"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
-"Language: fr_FR\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-SearchPath-0: .\n"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:62
-#, python-format
+#: models/online_bank_statement_provider_paypal.py:23
+msgid "General PayPal-to-PayPal payment"
+msgstr "Paiement PayPal de la PayPal à l’hôpital"
+
+#: models/online_bank_statement_provider_paypal.py:24
+msgid "MassPay payment"
+msgstr "Paiement MassPay"
+
+#: models/online_bank_statement_provider_paypal.py:25
+msgid "Subscription payment"
+msgstr "Paiement par abonnement"
+
+#: models/online_bank_statement_provider_paypal.py:26
+msgid "Pre-approved payment (BillUser API)"
+msgstr "Paiement pré-approuvé (API BillUser)"
+
+#: models/online_bank_statement_provider_paypal.py:27
+msgid "eBay auction payment"
+msgstr "paiement aux enchères eBay"
+
+#: models/online_bank_statement_provider_paypal.py:28
+msgid "Direct payment API"
+msgstr "API de paiement direct"
+
+#: models/online_bank_statement_provider_paypal.py:29
+msgid "PayPal Checkout APIs"
+msgstr "PayPal API de paiement"
+
+#: models/online_bank_statement_provider_paypal.py:30
+msgid "Website payments standard payment"
+msgstr "Paiement standard des paiements sur le site Web"
+
+#: models/online_bank_statement_provider_paypal.py:31
+msgid "Postage payment to carrier"
+msgstr "Paiement d’affranchissement au transporteur"
+
+#: models/online_bank_statement_provider_paypal.py:32
+msgid "Gift certificate payment, purchase of gift certificate"
+msgstr "Paiement d’un certificat-cadeau, achat d’un certificat-cadeau"
+
+#: models/online_bank_statement_provider_paypal.py:33
+msgid "Third-party auction payment"
+msgstr "Paiement aux enchères par des tiers"
+
+#: models/online_bank_statement_provider_paypal.py:34
+msgid "Mobile payment, made through a mobile phone"
+msgstr "Paiement mobile, effectué via un téléphone mobile"
+
+#: models/online_bank_statement_provider_paypal.py:35
+msgid "Virtual terminal payment"
+msgstr "Paiement de terminaux virtuels"
+
+#: models/online_bank_statement_provider_paypal.py:36
+msgid "Donation payment"
+msgstr "Paiement des dons"
+
+#: models/online_bank_statement_provider_paypal.py:37
+msgid "Rebate payments"
+msgstr "Paiements de remboursement"
+
+#: models/online_bank_statement_provider_paypal.py:38
+msgid "Third-party payout"
+msgstr "Paiement par des tiers"
+
+#: models/online_bank_statement_provider_paypal.py:39
+msgid "Third-party recoupment"
+msgstr "Récupération par des tiers"
+
+#: models/online_bank_statement_provider_paypal.py:40
+msgid "Store-to-store transfers"
+msgstr "Transferts magasin à magasin"
+
+#: models/online_bank_statement_provider_paypal.py:41
+msgid "PayPal Here payment"
+msgstr "PayPal Ici paiement"
+
+#: models/online_bank_statement_provider_paypal.py:42
+msgid "Generic instrument-funded payment"
+msgstr "Paiement générique financé par des instruments"
+
+#: models/online_bank_statement_provider_paypal.py:43
+msgid "General non-payment fee"
+msgstr "Frais généraux de non-paiement"
+
+#: models/online_bank_statement_provider_paypal.py:44
+msgid "Website payments. Pro account monthly fee"
+msgstr "Paiements sur le site Web. Frais mensuels du compte Pro"
+
+#: models/online_bank_statement_provider_paypal.py:45
+msgid "Foreign bank withdrawal fee"
+msgstr "Frais de retrait bancaire à l’étranger"
+
+#: models/online_bank_statement_provider_paypal.py:46
+msgid "WorldLink check withdrawal fee"
+msgstr "WorldLink vérifier les frais de retrait"
+
+#: models/online_bank_statement_provider_paypal.py:47
+msgid "Mass payment batch fee"
+msgstr "Frais de lot de paiement de masse"
+
+#: models/online_bank_statement_provider_paypal.py:48
+msgid "Check withdrawal"
+msgstr "Vérifier le retrait"
+
+#: models/online_bank_statement_provider_paypal.py:49
+msgid "Chargeback processing fee"
+msgstr "Frais de traitement de la réduction des frais"
+
+#: models/online_bank_statement_provider_paypal.py:50
+msgid "Payment fee"
+msgstr "Frais de transaction"
+
+#: models/online_bank_statement_provider_paypal.py:51
+msgid "ATM withdrawal"
+msgstr "Retrait des guichets automatiques"
+
+#: models/online_bank_statement_provider_paypal.py:52
+msgid "Auto-sweep from account"
+msgstr "Balayage automatique du compte"
+
+#: models/online_bank_statement_provider_paypal.py:53
+msgid "International credit card withdrawal"
+msgstr "Retrait international de carte de crédit"
+
+#: models/online_bank_statement_provider_paypal.py:54
+msgid "Warranty fee for warranty purchase"
+msgstr "Frais de garantie pour l’achat sous garantie"
+
+#: models/online_bank_statement_provider_paypal.py:55
+msgid "Gift certificate expiration fee"
+msgstr "Frais d’expiration des certificats-cadeaux"
+
+#: models/online_bank_statement_provider_paypal.py:56
+msgid "Partner fee"
+msgstr "Frais de partenaire"
+
+#: models/online_bank_statement_provider_paypal.py:57
+msgid "General currency conversion"
+msgstr "Conversion générale des devises"
+
+#: models/online_bank_statement_provider_paypal.py:58
+msgid "User-initiated currency conversion"
+msgstr "Conversion de devises initiée par l’utilisateur"
+
+#: models/online_bank_statement_provider_paypal.py:59
+msgid "Currency conversion required to cover negative balance"
+msgstr "Conversion de devises nécessaire pour couvrir le solde négatif"
+
+#: models/online_bank_statement_provider_paypal.py:60
+msgid "General funding of PayPal account"
+msgstr "Financement général du compte PayPal santé"
+
+#: models/online_bank_statement_provider_paypal.py:61
+msgid "PayPal balance manager funding of PayPal account"
+msgstr "PayPal de gestionnaire de solde de PayPal compte"
+
+#: models/online_bank_statement_provider_paypal.py:62
 msgid "ACH funding for funds recovery from account balance"
 msgstr ""
+"Financement de l’ACH pour le recouvrement des fonds à partir du solde du "
+"compte"
 
-#. module: account_bank_statement_import_online_paypal
-#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_paypal.online_bank_statement_provider_form
-msgid "API base"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:51
-#, python-format
-msgid "ATM withdrawal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:128
-#, python-format
-msgid "Account hold for ACH deposit"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:127
-#, python-format
-msgid "Account hold for open authorization"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:160
-#, python-format
-msgid "Account receivable for shipping"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:52
-#, python-format
-msgid "Auto-sweep from account"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:65
-#, python-format
-msgid "AutoSweep"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:131
-#, python-format
-msgid "BML credit, transfer from BML"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:137
-#, python-format
-msgid "BML withdrawal, transfer to BML"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:78
-#, python-format
-msgid "Balance manager account bonus"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:93
-#, python-format
-msgid "Bill pay transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:155
-#, python-format
-msgid "Blocked payments"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:84
-#, python-format
-msgid "Bonus for first ACH use"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:132
-#, python-format
-msgid "Buyer credit payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:133
-#, python-format
-msgid "Buyer credit payment withdrawal, transfer to BML"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:105
-#, python-format
-msgid "Cancellation of hold for dispute resolution"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:117
-#, python-format
-msgid "Charge-off adjustment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:115
-#, python-format
-msgid "Chargeback"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:121
-#, python-format
-msgid "Chargeback cancellation"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:49
-#, python-format
-msgid "Chargeback processing fee"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:120
-#, python-format
-msgid "Chargeback re-presentment rejection"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:116
-#, python-format
-msgid "Chargeback reversal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:48
-#, python-format
-msgid "Check withdrawal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_paypal.online_bank_statement_provider_form
-msgid "Client ID"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:90
-#, python-format
-msgid "Coupon redemption"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:86
-#, python-format
-msgid "Credit card cash back bonus"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:74
-#, python-format
-msgid "Credit card deposit for negative PayPal account balance"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:85
-#, python-format
-msgid "Credit card security charge refund"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:59
-#, python-format
-msgid "Currency conversion required to cover negative balance"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:76
-#, python-format
-msgid "Debit card cash back bonus"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:158
-#, python-format
-msgid "Deferred disbursement, funds collected for disbursement"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:159
-#, python-format
-msgid "Delayed disbursement, funds disbursed"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:28
-#, python-format
-msgid "Direct payment API"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:165
-#, python-format
-msgid "Display only transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:36
-#, python-format
-msgid "Donation payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:63
-#, python-format
+#: models/online_bank_statement_provider_paypal.py:63
 msgid "Electronic funds transfer (EFT)"
-msgstr ""
+msgstr "Transfert électronique de fonds (EFT)"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:370
-#, python-format
-msgid "Failed to acquire token using Client ID and Secret!"
-msgstr ""
-"Vous n’avez pas réussi à acquérir un jeton à l’aide de l’id client et du "
-"secret !"
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:248
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:274
-#, python-format
-msgid "Failed to resolve transaction %s (%s)"
-msgstr "Échec de la résolution de la transaction %s (%s)"
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:344
-#, python-format
-msgid "Fee for %s"
-msgstr "Frais pour %s"
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:103
-#, python-format
-msgid "Fee refund"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:102
-#, python-format
-msgid "Fee reversal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:45
-#, python-format
-msgid "Foreign bank withdrawal fee"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:154
-#, python-format
-msgid "Funds available"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:153
-#, python-format
-msgid "Funds not yet available"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:161
-#, python-format
-msgid "Funds payable: PayPal-provided funds that must be paid back"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:162
-#, python-format
-msgid "Funds receivable: PayPal-provided funds that are being paid back"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:66
-#, python-format
-msgid "General PayPal debit card transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:23
-#, python-format
-msgid "General PayPal-to-PayPal payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:114
-#, python-format
-msgid "General account adjustment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:138
-#, python-format
-msgid "General adjustment without business-related event"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:122
-#, python-format
-msgid "General authorization"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:75
-#, python-format
-msgid "General bonus"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:136
-#, python-format
-msgid "General buyer credit payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:73
-#, python-format
-msgid "General credit card deposit"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:72
-#, python-format
-msgid "General credit card withdrawal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:57
-#, python-format
-msgid "General currency conversion"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:125
-#, python-format
-msgid "General dividend"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:60
-#, python-format
-msgid "General funding of PayPal account"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:143
-#, python-format
-msgid "General hold"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:144
-#, python-format
-msgid "General hold release"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:87
-#, python-format
-msgid "General incentive or certificate redemption"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:139
-#, python-format
-msgid "General intra-account transfer"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:43
-#, python-format
-msgid "General non-payment fee"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:94
-#, python-format
-msgid "General reversal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:126
-#, python-format
-msgid "General temporary hold"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:64
-#, python-format
+#: models/online_bank_statement_provider_paypal.py:64
 msgid "General withdrawal from PayPal account"
-msgstr ""
+msgstr "Retrait général de PayPal compte"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:134
-#, python-format
-msgid "General withdrawal to non-bank institution"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:65
+msgid "AutoSweep"
+msgstr "Balayage automatique"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:42
-#, python-format
-msgid "Generic instrument-funded payment"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:66
+msgid "General PayPal debit card transaction"
+msgstr "Transaction générale PayPal carte de débit"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:113
-#, python-format
-msgid "Generic instrument/Open Wallet reversals (buyer side)"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:67
+msgid "Virtual PayPal debit card transaction"
+msgstr "Transaction virtuelle PayPal carte de débit"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:112
-#, python-format
+#: models/online_bank_statement_provider_paypal.py:68
+msgid "PayPal debit card withdrawal to ATM"
+msgstr "PayPal de carte de débit au guichet automatique"
+
+#: models/online_bank_statement_provider_paypal.py:69
+msgid "Hidden virtual PayPal debit card transaction"
+msgstr "Paiement virtuel caché PayPal transaction par carte de débit"
+
+#: models/online_bank_statement_provider_paypal.py:70
+msgid "PayPal debit card cash advance"
+msgstr "PayPal’avance de fonds de la carte de débit"
+
+#: models/online_bank_statement_provider_paypal.py:71
+msgid "PayPal debit authorization"
+msgstr "PayPal de débit"
+
+#: models/online_bank_statement_provider_paypal.py:72
+msgid "General credit card withdrawal"
+msgstr "Retrait général de la carte de crédit"
+
+#: models/online_bank_statement_provider_paypal.py:73
+msgid "General credit card deposit"
+msgstr "Dépôt général par carte de crédit"
+
+#: models/online_bank_statement_provider_paypal.py:74
+msgid "Credit card deposit for negative PayPal account balance"
+msgstr "Dépôt par carte de crédit pour solde PayPal de compte"
+
+#: models/online_bank_statement_provider_paypal.py:75
+msgid "General bonus"
+msgstr "Bonus général"
+
+#: models/online_bank_statement_provider_paypal.py:76
+msgid "Debit card cash back bonus"
+msgstr "Bonus de remise en argent par carte de débit"
+
+#: models/online_bank_statement_provider_paypal.py:77
+msgid "Merchant referral account bonus"
+msgstr "Bonus de compte de référence marchand"
+
+#: models/online_bank_statement_provider_paypal.py:78
+msgid "Balance manager account bonus"
+msgstr "Bonus de compte de gestionnaire de solde"
+
+#: models/online_bank_statement_provider_paypal.py:79
+msgid "PayPal buyer warranty bonus"
+msgstr "PayPal de garantie de l’acheteur"
+
+#: models/online_bank_statement_provider_paypal.py:81
+msgid ""
+"PayPal protection bonus, payout for PayPal buyer protection, payout for full "
+"protection with PayPal buyer credit."
+msgstr ""
+"PayPal de protection, paiement pour la protection PayPal l’acheteur, "
+"paiement pour une protection complète avec PayPal d’acheteur."
+
+#: models/online_bank_statement_provider_paypal.py:84
+msgid "Bonus for first ACH use"
+msgstr "Bonus pour la première utilisation d’ACH"
+
+#: models/online_bank_statement_provider_paypal.py:85
+msgid "Credit card security charge refund"
+msgstr "Remboursement des frais de sécurité par carte de crédit"
+
+#: models/online_bank_statement_provider_paypal.py:86
+msgid "Credit card cash back bonus"
+msgstr "Bonus de remise en argent par carte de crédit"
+
+#: models/online_bank_statement_provider_paypal.py:87
+msgid "General incentive or certificate redemption"
+msgstr "Incitation générale ou rachat de certificat"
+
+#: models/online_bank_statement_provider_paypal.py:88
+#: models/online_bank_statement_provider_paypal.py:152
+msgid "Gift certificate redemption"
+msgstr "Rachat de certificat-cadeau"
+
+#: models/online_bank_statement_provider_paypal.py:89
+msgid "Points incentive redemption"
+msgstr "Rachat d’incitation de points"
+
+#: models/online_bank_statement_provider_paypal.py:90
+msgid "Coupon redemption"
+msgstr "Validation du code promo"
+
+#: models/online_bank_statement_provider_paypal.py:91
+msgid "eBay loyalty incentive"
+msgstr "incitation à la fidélité eBay"
+
+#: models/online_bank_statement_provider_paypal.py:92
+msgid "Offers used as funding source"
+msgstr "Offres utilisées comme source de financement"
+
+#: models/online_bank_statement_provider_paypal.py:93
+msgid "Bill pay transaction"
+msgstr "Transaction de paiement de facture"
+
+#: models/online_bank_statement_provider_paypal.py:94
+msgid "General reversal"
+msgstr "Inversion générale"
+
+#: models/online_bank_statement_provider_paypal.py:95
+msgid "Reversal of ACH withdrawal transaction"
+msgstr "Annulation de la transaction de retrait d’ACH"
+
+#: models/online_bank_statement_provider_paypal.py:96
+msgid "Reversal of debit card transaction"
+msgstr "Inversion de la transaction par carte de débit"
+
+#: models/online_bank_statement_provider_paypal.py:97
+msgid "Reversal of points usage"
+msgstr "Inversion de l’utilisation des points"
+
+#: models/online_bank_statement_provider_paypal.py:98
+msgid "Reversal of ACH deposit"
+msgstr "Inversion du gisement ACH"
+
+#: models/online_bank_statement_provider_paypal.py:99
+msgid "Reversal of general account hold"
+msgstr "Inversion de la comptabilité générale"
+
+#: models/online_bank_statement_provider_paypal.py:100
+msgid "Payment reversal, initiated by PayPal"
+msgstr "Inversion de paiement, initiée par PayPal"
+
+#: models/online_bank_statement_provider_paypal.py:101
+msgid "Payment refund, initiated by merchant"
+msgstr "Remboursement de paiement, initié par le commerçant"
+
+#: models/online_bank_statement_provider_paypal.py:102
+msgid "Fee reversal"
+msgstr "Inversion des frais"
+
+#: models/online_bank_statement_provider_paypal.py:103
+msgid "Fee refund"
+msgstr "Remboursement des frais"
+
+#: models/online_bank_statement_provider_paypal.py:104
+msgid "Hold for dispute investigation"
+msgstr "Tenir pour l’enquête sur les différends"
+
+#: models/online_bank_statement_provider_paypal.py:105
+msgid "Cancellation of hold for dispute resolution"
+msgstr "Annulation de la retenue suite au règlement des différends"
+
+#: models/online_bank_statement_provider_paypal.py:106
+msgid "MAM reversal"
+msgstr "Inversion MAM"
+
+#: models/online_bank_statement_provider_paypal.py:107
+msgid "Non-reference credit payment"
+msgstr "Paiement de crédit non référencé"
+
+#: models/online_bank_statement_provider_paypal.py:108
+msgid "MassPay reversal transaction"
+msgstr "Transaction d’inversion MassPay"
+
+#: models/online_bank_statement_provider_paypal.py:109
+msgid "MassPay refund transaction"
+msgstr "Transaction de remboursement MassPay"
+
+#: models/online_bank_statement_provider_paypal.py:110
+msgid "Instant payment review (IPR) reversal"
+msgstr "Inversion instantanée de l’examen des paiements (DPI)"
+
+#: models/online_bank_statement_provider_paypal.py:111
+msgid "Rebate or cash back reversal"
+msgstr "Remise ou inversion de remise en espèces"
+
+#: models/online_bank_statement_provider_paypal.py:112
 msgid "Generic instrument/Open Wallet reversals (seller side)"
 msgstr ""
+"Inversions génériques de l’instrument/portefeuille ouvert (côté vendeur)"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:157
-#, python-format
-msgid "Generic instrument/Open Wallet transaction"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:113
+msgid "Generic instrument/Open Wallet reversals (buyer side)"
+msgstr "Instruments génériques/inversions open wallet (côté acheteur)"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:55
-#, python-format
-msgid "Gift certificate expiration fee"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:114
+msgid "General account adjustment"
+msgstr "Compte d’ajustement"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:32
-#, python-format
-msgid "Gift certificate payment, purchase of gift certificate"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:115
+msgid "Chargeback"
+msgstr "Rétrofacturation"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:151
-#, python-format
-msgid "Gift certificate purchase"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:116
+msgid "Chargeback reversal"
+msgstr "Inversion de chargeback"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:88
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:152
-#, python-format
-msgid "Gift certificate redemption"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:117
+msgid "Charge-off adjustment"
+msgstr "Ajustement de frais"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:69
-#, python-format
-msgid "Hidden virtual PayPal debit card transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:104
-#, python-format
-msgid "Hold for dispute investigation"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:118
-#, python-format
+#: models/online_bank_statement_provider_paypal.py:118
 msgid "Incentive adjustment"
+msgstr "Ajustement incitatif"
+
+#: models/online_bank_statement_provider_paypal.py:119
+msgid "Reimbursement of chargeback"
+msgstr "Remboursement de la chargeback"
+
+#: models/online_bank_statement_provider_paypal.py:120
+msgid "Chargeback re-presentment rejection"
+msgstr "Rejet de la ré-présentation de chargeback"
+
+#: models/online_bank_statement_provider_paypal.py:121
+msgid "Chargeback cancellation"
+msgstr "Annulation de frais"
+
+#: models/online_bank_statement_provider_paypal.py:122
+msgid "General authorization"
+msgstr "Autorisation générale"
+
+#: models/online_bank_statement_provider_paypal.py:123
+msgid "Reauthorization"
+msgstr "Reauthorization"
+
+#: models/online_bank_statement_provider_paypal.py:124
+msgid "Void of authorization"
+msgstr "Annulation de l’autorisation"
+
+#: models/online_bank_statement_provider_paypal.py:125
+msgid "General dividend"
+msgstr "Dividende général"
+
+#: models/online_bank_statement_provider_paypal.py:126
+msgid "General temporary hold"
+msgstr "Prise temporaire générale"
+
+#: models/online_bank_statement_provider_paypal.py:127
+msgid "Account hold for open authorization"
+msgstr "Tenir compte de l’autorisation ouverte"
+
+#: models/online_bank_statement_provider_paypal.py:128
+msgid "Account hold for ACH deposit"
+msgstr "Prise de compte pour le dépôt ACH"
+
+#: models/online_bank_statement_provider_paypal.py:129
+msgid "Temporary hold on available balance"
+msgstr "Retenue temporaire sur le solde disponible"
+
+#: models/online_bank_statement_provider_paypal.py:130
+msgid "PayPal buyer credit payment funding"
+msgstr "PayPal de paiement de crédit d’acheteur"
+
+#: models/online_bank_statement_provider_paypal.py:131
+msgid "BML credit, transfer from BML"
+msgstr "Crédit BML, transfert de BML"
+
+#: models/online_bank_statement_provider_paypal.py:132
+msgid "Buyer credit payment"
+msgstr "Paiement de crédit d’acheteur"
+
+#: models/online_bank_statement_provider_paypal.py:133
+msgid "Buyer credit payment withdrawal, transfer to BML"
+msgstr "Retrait de paiement de crédit d’acheteur, transfert à BML"
+
+#: models/online_bank_statement_provider_paypal.py:134
+msgid "General withdrawal to non-bank institution"
+msgstr "Retrait général à l’institution non bancaire"
+
+#: models/online_bank_statement_provider_paypal.py:135
+msgid "WorldLink withdrawal"
+msgstr "Retrait de WorldLink"
+
+#: models/online_bank_statement_provider_paypal.py:136
+msgid "General buyer credit payment"
+msgstr "Paiement général de crédit d’acheteur"
+
+#: models/online_bank_statement_provider_paypal.py:137
+msgid "BML withdrawal, transfer to BML"
+msgstr "Retrait de BML, transfert à BML"
+
+#: models/online_bank_statement_provider_paypal.py:138
+msgid "General adjustment without business-related event"
+msgstr "Ajustement général sans événement lié à l’entreprise"
+
+#: models/online_bank_statement_provider_paypal.py:139
+msgid "General intra-account transfer"
+msgstr "Transfert général intra-compte"
+
+#: models/online_bank_statement_provider_paypal.py:140
+msgid "Settlement consolidation"
+msgstr "Consolidation des règlements"
+
+#: models/online_bank_statement_provider_paypal.py:141
+msgid "Transfer of funds from payable"
+msgstr "Transfert de fonds à partir de payables"
+
+#: models/online_bank_statement_provider_paypal.py:142
+msgid "Transfer to external GL entity"
+msgstr "Transfert vers une entité GL externe"
+
+#: models/online_bank_statement_provider_paypal.py:143
+msgid "General hold"
+msgstr "Prise générale"
+
+#: models/online_bank_statement_provider_paypal.py:144
+msgid "General hold release"
+msgstr "Libération générale de la prise"
+
+#: models/online_bank_statement_provider_paypal.py:145
+msgid "Reserve hold"
+msgstr "Réserve maintenez"
+
+#: models/online_bank_statement_provider_paypal.py:146
+msgid "Reserve release"
+msgstr "Libération de réserve"
+
+#: models/online_bank_statement_provider_paypal.py:147
+msgid "Payment review hold"
+msgstr "Tenir l’examen des paiements"
+
+#: models/online_bank_statement_provider_paypal.py:148
+msgid "Payment review release"
+msgstr "Communiqué d’examen des paiements"
+
+#: models/online_bank_statement_provider_paypal.py:149
+msgid "Payment hold"
+msgstr "Prise de paiement"
+
+#: models/online_bank_statement_provider_paypal.py:150
+msgid "Payment hold release"
+msgstr "Libération de la prise de paiement"
+
+#: models/online_bank_statement_provider_paypal.py:151
+msgid "Gift certificate purchase"
+msgstr "Achat d’un certificat-cadeau"
+
+#: models/online_bank_statement_provider_paypal.py:153
+msgid "Funds not yet available"
+msgstr "Fonds non encore disponibles"
+
+#: models/online_bank_statement_provider_paypal.py:154
+msgid "Funds available"
+msgstr "Fonds disponibles"
+
+#: models/online_bank_statement_provider_paypal.py:155
+msgid "Blocked payments"
+msgstr "Paiements bloqués"
+
+#: models/online_bank_statement_provider_paypal.py:156
+msgid "Transfer to and from a credit-card-funded restricted balance"
 msgstr ""
+"Transfert vers et depuis un solde restreint financé par carte de crédit"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:110
-#, python-format
-msgid "Instant payment review (IPR) reversal"
+#: models/online_bank_statement_provider_paypal.py:157
+msgid "Generic instrument/Open Wallet transaction"
+msgstr "Transaction instrument générique/Portefeuille ouvert"
+
+#: models/online_bank_statement_provider_paypal.py:158
+msgid "Deferred disbursement, funds collected for disbursement"
+msgstr "Décaissement différé, fonds collectés pour le décaissement"
+
+#: models/online_bank_statement_provider_paypal.py:159
+msgid "Delayed disbursement, funds disbursed"
+msgstr "Décaissement retardé, fonds décaissés"
+
+#: models/online_bank_statement_provider_paypal.py:160
+msgid "Account receivable for shipping"
+msgstr "Compte débiteur pour l’expédition"
+
+#: models/online_bank_statement_provider_paypal.py:161
+msgid "Funds payable: PayPal-provided funds that must be paid back"
 msgstr ""
+"Fonds à payer : PayPal de fonds fournis par l’argent qui doivent être "
+"remboursés"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:53
-#, python-format
-msgid "International credit card withdrawal"
+#: models/online_bank_statement_provider_paypal.py:163
+msgid "Funds receivable: PayPal-provided funds that are being paid back"
 msgstr ""
+"Fonds à recevoir : PayPal de fonds fournis par les fonds qui sont remboursés"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:368
-#, python-format
-msgid "Invalid token type!"
-msgstr "Type de jeton invalide!"
+#: models/online_bank_statement_provider_paypal.py:165
+msgid "Display only transaction"
+msgstr "Afficher uniquement la transaction"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:310
-#, python-format
-msgid "Invoice %s"
-msgstr "Facture %s"
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:106
-#, python-format
-msgid "MAM reversal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:47
-#, python-format
-msgid "Mass payment batch fee"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:24
-#, python-format
-msgid "MassPay payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:109
-#, python-format
-msgid "MassPay refund transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:108
-#, python-format
-msgid "MassPay reversal transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:77
-#, python-format
-msgid "Merchant referral account bonus"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:34
-#, python-format
-msgid "Mobile payment, made through a mobile phone"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:541
-#, python-format
-msgid "No authentication specified!"
-msgstr "Aucune authentification spécifiée!"
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:107
-#, python-format
-msgid "Non-reference credit payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:92
-#, python-format
-msgid "Offers used as funding source"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: model:ir.model,name:account_bank_statement_import_online_paypal.model_online_bank_statement_provider
-msgid "Online Bank Statement Provider"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:166
-#, python-format
+#: models/online_bank_statement_provider_paypal.py:166
 msgid "Other"
-msgstr ""
+msgstr "Autre"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:56
-#, python-format
-msgid "Partner fee"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:364
-#, python-format
-msgid "PayPal App features are configured incorrectly!"
-msgstr ""
-"Les fonctionnalités de l’application PayPal sont configurées de manière "
-"incorrecte !"
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:29
-#, python-format
-msgid "PayPal Checkout APIs"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:41
-#, python-format
-msgid "PayPal Here payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:199
-#, python-format
+#: models/online_bank_statement_provider_paypal.py:200
 msgid ""
 "PayPal allows retrieving transactions only up to 3 years in the past. Please "
 "import older transactions manually. See https://www.paypal.com/us/smarthelp/"
@@ -627,322 +594,52 @@ msgstr ""
 "manuellement. Voir https://www.PayPal.com/us/smarthelp/article/why-can’t-i-"
 "access-transaction-history-greater-than-3-years-ts2241"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:61
+#: models/online_bank_statement_provider_paypal.py:248
+#: models/online_bank_statement_provider_paypal.py:274
 #, python-format
-msgid "PayPal balance manager funding of PayPal account"
-msgstr ""
+msgid "Failed to resolve transaction %s (%s)"
+msgstr "Échec de la résolution de la transaction %s (%s)"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:130
+#: models/online_bank_statement_provider_paypal.py:310
 #, python-format
-msgid "PayPal buyer credit payment funding"
-msgstr ""
+msgid "Invoice %s"
+msgstr "Facture %s"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:79
+#: models/online_bank_statement_provider_paypal.py:344
 #, python-format
-msgid "PayPal buyer warranty bonus"
-msgstr ""
+msgid "Fee for %s"
+msgstr "Frais pour %s"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:71
-#, python-format
-msgid "PayPal debit authorization"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:70
-#, python-format
-msgid "PayPal debit card cash advance"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:68
-#, python-format
-msgid "PayPal debit card withdrawal to ATM"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:80
-#, python-format
-msgid ""
-"PayPal protection bonus, payout for PayPal buyer protection, payout for full "
-"protection with PayPal buyer credit."
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:50
-#, python-format
-msgid "Payment fee"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:149
-#, python-format
-msgid "Payment hold"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:150
-#, python-format
-msgid "Payment hold release"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:101
-#, python-format
-msgid "Payment refund, initiated by merchant"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:100
-#, python-format
-msgid "Payment reversal, initiated by PayPal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:147
-#, python-format
-msgid "Payment review hold"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:148
-#, python-format
-msgid "Payment review release"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:89
-#, python-format
-msgid "Points incentive redemption"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:31
-#, python-format
-msgid "Postage payment to carrier"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:26
-#, python-format
-msgid "Pre-approved payment (BillUser API)"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:123
-#, python-format
-msgid "Reauthorization"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:111
-#, python-format
-msgid "Rebate or cash back reversal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:37
-#, python-format
-msgid "Rebate payments"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:119
-#, python-format
-msgid "Reimbursement of chargeback"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:145
-#, python-format
-msgid "Reserve hold"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:146
-#, python-format
-msgid "Reserve release"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:98
-#, python-format
-msgid "Reversal of ACH deposit"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:95
-#, python-format
-msgid "Reversal of ACH withdrawal transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:96
-#, python-format
-msgid "Reversal of debit card transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:99
-#, python-format
-msgid "Reversal of general account hold"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:97
-#, python-format
-msgid "Reversal of points usage"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_paypal.online_bank_statement_provider_form
-msgid "Secret"
-msgstr "Secret"
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:140
-#, python-format
-msgid "Settlement consolidation"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:40
-#, python-format
-msgid "Store-to-store transfers"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:25
-#, python-format
-msgid "Subscription payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:129
-#, python-format
-msgid "Temporary hold on available balance"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:33
-#, python-format
-msgid "Third-party auction payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:38
-#, python-format
-msgid "Third-party payout"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:39
-#, python-format
-msgid "Third-party recoupment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:349
+#: models/online_bank_statement_provider_paypal.py:349
 #, python-format
 msgid "Transaction fee for %s"
 msgstr "Frais de transaction pour %s"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:141
-#, python-format
-msgid "Transfer of funds from payable"
+#: models/online_bank_statement_provider_paypal.py:365
+msgid "PayPal App features are configured incorrectly!"
 msgstr ""
+"Les fonctionnalités de l’application PayPal sont configurées de manière "
+"incorrecte !"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:156
-#, python-format
-msgid "Transfer to and from a credit-card-funded restricted balance"
+#: models/online_bank_statement_provider_paypal.py:368
+msgid "Invalid token type!"
+msgstr "Type de jeton invalide!"
+
+#: models/online_bank_statement_provider_paypal.py:371
+msgid "Failed to acquire token using Client ID and Secret!"
 msgstr ""
+"Vous n’avez pas réussi à acquérir un jeton à l’aide de l’id client et du "
+"secret !"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:142
-#, python-format
-msgid "Transfer to external GL entity"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:557
-#, python-format
-msgid "Unknown authentication specified!"
-msgstr "Authentification inconnue spécifiée!"
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:505
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:511
-#, python-format
+#: models/online_bank_statement_provider_paypal.py:505
+#: models/online_bank_statement_provider_paypal.py:511
 msgid "Unknown error"
 msgstr "Erreur inconnue"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:58
-#, python-format
-msgid "User-initiated currency conversion"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:541
+msgid "No authentication specified!"
+msgstr "Aucune authentification spécifiée!"
 
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:67
-#, python-format
-msgid "Virtual PayPal debit card transaction"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:35
-#, python-format
-msgid "Virtual terminal payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:124
-#, python-format
-msgid "Void of authorization"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:54
-#, python-format
-msgid "Warranty fee for warranty purchase"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:30
-#, python-format
-msgid "Website payments standard payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:44
-#, python-format
-msgid "Website payments. Pro account monthly fee"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:46
-#, python-format
-msgid "WorldLink check withdrawal fee"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:135
-#, python-format
-msgid "WorldLink withdrawal"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:27
-#, python-format
-msgid "eBay auction payment"
-msgstr ""
-
-#. module: account_bank_statement_import_online_paypal
-#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:91
-#, python-format
-msgid "eBay loyalty incentive"
-msgstr ""
+#: models/online_bank_statement_provider_paypal.py:557
+msgid "Unknown authentication specified!"
+msgstr "Authentification inconnue spécifiée!"

--- a/account_bank_statement_import_online_paypal/i18n/fr_FR.po
+++ b/account_bank_statement_import_online_paypal/i18n/fr_FR.po
@@ -1,0 +1,948 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_import_online_paypal
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:62
+#, python-format
+msgid "ACH funding for funds recovery from account balance"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_paypal.online_bank_statement_provider_form
+msgid "API base"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:51
+#, python-format
+msgid "ATM withdrawal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:128
+#, python-format
+msgid "Account hold for ACH deposit"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:127
+#, python-format
+msgid "Account hold for open authorization"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:160
+#, python-format
+msgid "Account receivable for shipping"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:52
+#, python-format
+msgid "Auto-sweep from account"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:65
+#, python-format
+msgid "AutoSweep"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:131
+#, python-format
+msgid "BML credit, transfer from BML"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:137
+#, python-format
+msgid "BML withdrawal, transfer to BML"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:78
+#, python-format
+msgid "Balance manager account bonus"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:93
+#, python-format
+msgid "Bill pay transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:155
+#, python-format
+msgid "Blocked payments"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:84
+#, python-format
+msgid "Bonus for first ACH use"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:132
+#, python-format
+msgid "Buyer credit payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:133
+#, python-format
+msgid "Buyer credit payment withdrawal, transfer to BML"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:105
+#, python-format
+msgid "Cancellation of hold for dispute resolution"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:117
+#, python-format
+msgid "Charge-off adjustment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:115
+#, python-format
+msgid "Chargeback"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:121
+#, python-format
+msgid "Chargeback cancellation"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:49
+#, python-format
+msgid "Chargeback processing fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:120
+#, python-format
+msgid "Chargeback re-presentment rejection"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:116
+#, python-format
+msgid "Chargeback reversal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:48
+#, python-format
+msgid "Check withdrawal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_paypal.online_bank_statement_provider_form
+msgid "Client ID"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:90
+#, python-format
+msgid "Coupon redemption"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:86
+#, python-format
+msgid "Credit card cash back bonus"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:74
+#, python-format
+msgid "Credit card deposit for negative PayPal account balance"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:85
+#, python-format
+msgid "Credit card security charge refund"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:59
+#, python-format
+msgid "Currency conversion required to cover negative balance"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:76
+#, python-format
+msgid "Debit card cash back bonus"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:158
+#, python-format
+msgid "Deferred disbursement, funds collected for disbursement"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:159
+#, python-format
+msgid "Delayed disbursement, funds disbursed"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:28
+#, python-format
+msgid "Direct payment API"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:165
+#, python-format
+msgid "Display only transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:36
+#, python-format
+msgid "Donation payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:63
+#, python-format
+msgid "Electronic funds transfer (EFT)"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:370
+#, python-format
+msgid "Failed to acquire token using Client ID and Secret!"
+msgstr ""
+"Vous n’avez pas réussi à acquérir un jeton à l’aide de l’id client et du "
+"secret !"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:248
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:274
+#, python-format
+msgid "Failed to resolve transaction %s (%s)"
+msgstr "Échec de la résolution de la transaction %s (%s)"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:344
+#, python-format
+msgid "Fee for %s"
+msgstr "Frais pour %s"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:103
+#, python-format
+msgid "Fee refund"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:102
+#, python-format
+msgid "Fee reversal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:45
+#, python-format
+msgid "Foreign bank withdrawal fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:154
+#, python-format
+msgid "Funds available"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:153
+#, python-format
+msgid "Funds not yet available"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:161
+#, python-format
+msgid "Funds payable: PayPal-provided funds that must be paid back"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:162
+#, python-format
+msgid "Funds receivable: PayPal-provided funds that are being paid back"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:66
+#, python-format
+msgid "General PayPal debit card transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:23
+#, python-format
+msgid "General PayPal-to-PayPal payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:114
+#, python-format
+msgid "General account adjustment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:138
+#, python-format
+msgid "General adjustment without business-related event"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:122
+#, python-format
+msgid "General authorization"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:75
+#, python-format
+msgid "General bonus"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:136
+#, python-format
+msgid "General buyer credit payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:73
+#, python-format
+msgid "General credit card deposit"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:72
+#, python-format
+msgid "General credit card withdrawal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:57
+#, python-format
+msgid "General currency conversion"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:125
+#, python-format
+msgid "General dividend"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:60
+#, python-format
+msgid "General funding of PayPal account"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:143
+#, python-format
+msgid "General hold"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:144
+#, python-format
+msgid "General hold release"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:87
+#, python-format
+msgid "General incentive or certificate redemption"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:139
+#, python-format
+msgid "General intra-account transfer"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:43
+#, python-format
+msgid "General non-payment fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:94
+#, python-format
+msgid "General reversal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:126
+#, python-format
+msgid "General temporary hold"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:64
+#, python-format
+msgid "General withdrawal from PayPal account"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:134
+#, python-format
+msgid "General withdrawal to non-bank institution"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:42
+#, python-format
+msgid "Generic instrument-funded payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:113
+#, python-format
+msgid "Generic instrument/Open Wallet reversals (buyer side)"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:112
+#, python-format
+msgid "Generic instrument/Open Wallet reversals (seller side)"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:157
+#, python-format
+msgid "Generic instrument/Open Wallet transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:55
+#, python-format
+msgid "Gift certificate expiration fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:32
+#, python-format
+msgid "Gift certificate payment, purchase of gift certificate"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:151
+#, python-format
+msgid "Gift certificate purchase"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:88
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:152
+#, python-format
+msgid "Gift certificate redemption"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:69
+#, python-format
+msgid "Hidden virtual PayPal debit card transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:104
+#, python-format
+msgid "Hold for dispute investigation"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:118
+#, python-format
+msgid "Incentive adjustment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:110
+#, python-format
+msgid "Instant payment review (IPR) reversal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:53
+#, python-format
+msgid "International credit card withdrawal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:368
+#, python-format
+msgid "Invalid token type!"
+msgstr "Type de jeton invalide!"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:310
+#, python-format
+msgid "Invoice %s"
+msgstr "Facture %s"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:106
+#, python-format
+msgid "MAM reversal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:47
+#, python-format
+msgid "Mass payment batch fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:24
+#, python-format
+msgid "MassPay payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:109
+#, python-format
+msgid "MassPay refund transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:108
+#, python-format
+msgid "MassPay reversal transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:77
+#, python-format
+msgid "Merchant referral account bonus"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:34
+#, python-format
+msgid "Mobile payment, made through a mobile phone"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:541
+#, python-format
+msgid "No authentication specified!"
+msgstr "Aucune authentification spécifiée!"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:107
+#, python-format
+msgid "Non-reference credit payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:92
+#, python-format
+msgid "Offers used as funding source"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: model:ir.model,name:account_bank_statement_import_online_paypal.model_online_bank_statement_provider
+msgid "Online Bank Statement Provider"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:166
+#, python-format
+msgid "Other"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:56
+#, python-format
+msgid "Partner fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:364
+#, python-format
+msgid "PayPal App features are configured incorrectly!"
+msgstr ""
+"Les fonctionnalités de l’application PayPal sont configurées de manière "
+"incorrecte !"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:29
+#, python-format
+msgid "PayPal Checkout APIs"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:41
+#, python-format
+msgid "PayPal Here payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:199
+#, python-format
+msgid ""
+"PayPal allows retrieving transactions only up to 3 years in the past. Please "
+"import older transactions manually. See https://www.paypal.com/us/smarthelp/"
+"article/why-can't-i-access-transaction-history-greater-than-3-years-ts2241"
+msgstr ""
+"PayPal permet de récupérer des transactions seulement jusqu’à 3 ans dans le "
+"passé. S’il vous plaît importer des transactions plus anciennes "
+"manuellement. Voir https://www.PayPal.com/us/smarthelp/article/why-can’t-i-"
+"access-transaction-history-greater-than-3-years-ts2241"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:61
+#, python-format
+msgid "PayPal balance manager funding of PayPal account"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:130
+#, python-format
+msgid "PayPal buyer credit payment funding"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:79
+#, python-format
+msgid "PayPal buyer warranty bonus"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:71
+#, python-format
+msgid "PayPal debit authorization"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:70
+#, python-format
+msgid "PayPal debit card cash advance"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:68
+#, python-format
+msgid "PayPal debit card withdrawal to ATM"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:80
+#, python-format
+msgid ""
+"PayPal protection bonus, payout for PayPal buyer protection, payout for full "
+"protection with PayPal buyer credit."
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:50
+#, python-format
+msgid "Payment fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:149
+#, python-format
+msgid "Payment hold"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:150
+#, python-format
+msgid "Payment hold release"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:101
+#, python-format
+msgid "Payment refund, initiated by merchant"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:100
+#, python-format
+msgid "Payment reversal, initiated by PayPal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:147
+#, python-format
+msgid "Payment review hold"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:148
+#, python-format
+msgid "Payment review release"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:89
+#, python-format
+msgid "Points incentive redemption"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:31
+#, python-format
+msgid "Postage payment to carrier"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:26
+#, python-format
+msgid "Pre-approved payment (BillUser API)"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:123
+#, python-format
+msgid "Reauthorization"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:111
+#, python-format
+msgid "Rebate or cash back reversal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:37
+#, python-format
+msgid "Rebate payments"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:119
+#, python-format
+msgid "Reimbursement of chargeback"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:145
+#, python-format
+msgid "Reserve hold"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:146
+#, python-format
+msgid "Reserve release"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:98
+#, python-format
+msgid "Reversal of ACH deposit"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:95
+#, python-format
+msgid "Reversal of ACH withdrawal transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:96
+#, python-format
+msgid "Reversal of debit card transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:99
+#, python-format
+msgid "Reversal of general account hold"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:97
+#, python-format
+msgid "Reversal of points usage"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_paypal.online_bank_statement_provider_form
+msgid "Secret"
+msgstr "Secret"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:140
+#, python-format
+msgid "Settlement consolidation"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:40
+#, python-format
+msgid "Store-to-store transfers"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:25
+#, python-format
+msgid "Subscription payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:129
+#, python-format
+msgid "Temporary hold on available balance"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:33
+#, python-format
+msgid "Third-party auction payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:38
+#, python-format
+msgid "Third-party payout"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:39
+#, python-format
+msgid "Third-party recoupment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:349
+#, python-format
+msgid "Transaction fee for %s"
+msgstr "Frais de transaction pour %s"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:141
+#, python-format
+msgid "Transfer of funds from payable"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:156
+#, python-format
+msgid "Transfer to and from a credit-card-funded restricted balance"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:142
+#, python-format
+msgid "Transfer to external GL entity"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:557
+#, python-format
+msgid "Unknown authentication specified!"
+msgstr "Authentification inconnue spécifiée!"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:505
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:511
+#, python-format
+msgid "Unknown error"
+msgstr "Erreur inconnue"
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:58
+#, python-format
+msgid "User-initiated currency conversion"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:67
+#, python-format
+msgid "Virtual PayPal debit card transaction"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:35
+#, python-format
+msgid "Virtual terminal payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:124
+#, python-format
+msgid "Void of authorization"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:54
+#, python-format
+msgid "Warranty fee for warranty purchase"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:30
+#, python-format
+msgid "Website payments standard payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:44
+#, python-format
+msgid "Website payments. Pro account monthly fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:46
+#, python-format
+msgid "WorldLink check withdrawal fee"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:135
+#, python-format
+msgid "WorldLink withdrawal"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:27
+#, python-format
+msgid "eBay auction payment"
+msgstr ""
+
+#. module: account_bank_statement_import_online_paypal
+#: code:addons/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py:91
+#, python-format
+msgid "eBay loyalty incentive"
+msgstr ""

--- a/account_bank_statement_import_online_ponto/i18n/fr_FR.po
+++ b/account_bank_statement_import_online_ponto/i18n/fr_FR.po
@@ -72,7 +72,7 @@ msgstr "Fournisseur de relevés bancaires en ligne"
 #: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:57
 #, python-format
 msgid "Please fill login and key."
-msgstr "S’il vous plaît remplir le login et la clé"
+msgstr "S’il vous plaît remplir le login et la clé."
 
 #. module: account_bank_statement_import_online_ponto
 #: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:73

--- a/account_bank_statement_import_online_ponto/i18n/fr_FR.po
+++ b/account_bank_statement_import_online_ponto/i18n/fr_FR.po
@@ -1,0 +1,113 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_import_online_ponto
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_import_online_ponto
+#: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:80
+#: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:96
+#, python-format
+msgid ""
+"%s \n"
+"\n"
+" %s"
+msgstr ""
+"%s \n"
+"\n"
+" %s"
+
+#. module: account_bank_statement_import_online_ponto
+#: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:115
+#, python-format
+msgid ""
+"Error during Create Synchronisation %s \n"
+"\n"
+" %s"
+msgstr ""
+"Erreur lors de la synchronisation de %s \n"
+"\n"
+"%s"
+
+#. module: account_bank_statement_import_online_ponto
+#: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:170
+#, python-format
+msgid ""
+"Error during get transaction.\n"
+"\n"
+"%s \n"
+"\n"
+" %s"
+msgstr ""
+"Erreur lors de l’import de la transaction.\n"
+"\n"
+"%s \n"
+"\n"
+"%s"
+
+#. module: account_bank_statement_import_online_ponto
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_ponto.online_bank_statement_provider_form
+msgid "Login"
+msgstr "Identifiant"
+
+#. module: account_bank_statement_import_online_ponto
+#: model:ir.model,name:account_bank_statement_import_online_ponto.model_online_bank_statement_provider
+msgid "Online Bank Statement Provider"
+msgstr "Fournisseur de relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online_ponto
+#: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:57
+#, python-format
+msgid "Please fill login and key."
+msgstr "S’il vous plaît remplir le login et la clé"
+
+#. module: account_bank_statement_import_online_ponto
+#: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:73
+#, python-format
+msgid "Ponto : no token"
+msgstr "Ponto : pas de jeton (token)"
+
+#. module: account_bank_statement_import_online_ponto
+#: code:addons/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py:194
+#, python-format
+msgid "Ponto : wrong configuration, unknow account %s"
+msgstr "Ponto : mauvaise configuration, compte inconnu %s"
+
+#. module: account_bank_statement_import_online_ponto
+#: model:ir.model.fields,field_description:account_bank_statement_import_online_ponto.field_online_bank_statement_provider__ponto_last_identifier
+msgid "Ponto Last Identifier"
+msgstr "Ponto Dernier Identificateur"
+
+#. module: account_bank_statement_import_online_ponto
+#: model:ir.model.fields,field_description:account_bank_statement_import_online_ponto.field_online_bank_statement_provider__ponto_token
+msgid "Ponto Token"
+msgstr "Jeton (Token) Ponto"
+
+#. module: account_bank_statement_import_online_ponto
+#: model:ir.model.fields,field_description:account_bank_statement_import_online_ponto.field_online_bank_statement_provider__ponto_token_expiration
+msgid "Ponto Token Expiration"
+msgstr "Expiration des jetons (token) ponto"
+
+#. module: account_bank_statement_import_online_ponto
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_ponto.online_bank_statement_provider_form
+#, fuzzy
+msgid "Reset Last identifier."
+msgstr "Réinitialisation Dernier identificateur."
+
+#. module: account_bank_statement_import_online_ponto
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_ponto.online_bank_statement_provider_form
+msgid "Secret Key"
+msgstr "Clé secrète"

--- a/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
+++ b/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
@@ -183,63 +183,6 @@ class OnlineBankStatementProviderPonto(models.Model):
         )
         return dt.replace(tzinfo=None)
 
-    def _ponto_synchronisation_account_details(self, account_id, subtype):
-        url = PONTO_ENDPOINT + '/synchronizations'
-        data = {'data': {
-            'type': 'synchronization',
-            'attributes': {
-                'resourceType': 'account',
-                'resourceId': account_id,
-                'subtype': subtype
-            }
-        }}
-        response = requests.post(url, verify=False,
-                                 headers=self._ponto_header(),
-                                 json=data)
-        if response.status_code in (200, 201, 400):
-            data = json.loads(response.text)
-            sync_id = data.get('attributes', {}).get('resourceId', False)
-        else:
-            raise UserError(_('Error during Create Synchronisation %s \n\n %s') % (
-                response.status_code, response.text))
-
-        # Check synchronisation
-        if not sync_id:
-            return
-        url = PONTO_ENDPOINT + '/synchronizations/' + sync_id
-        number = 0
-        while number == 100:
-            number += 1
-            response = requests.get(url, verify=False, headers=self._ponto_header())
-            if response.status_code == 200:
-                data = json.loads(response.text)
-                status = data.get('status', {})
-                if status in ('success', 'error'):
-                    return
-            time.sleep(4)
-
-    def _ponto_get_account_endind_balance(self,account_id,date_since,date_until):
-        page_url = PONTO_ENDPOINT + '/accounts/' + account_id
-        params = {'limit': 1}
-
-        while page_url:
-            response = requests.get(page_url, verify=False, params=params,
-                                    headers=self._ponto_header())
-            if response.status_code == 200:
-                data = json.loads(response.text)
-                accountInfo = data.get('data', [])
-                if accountInfo:
-                    account_ending_balance = accountInfo.get(
-                        'attributes', {}).get('availableBalance')
-
-            else:
-                raise UserError(
-                      _('Error during get account informations.\n\n%s \n\n %s') % (
-                         response.status_code, response.text))
-
-        return account_ending_balance
-
-
     def _ponto_obtain_statement_data(self, date_since, date_until):
         self.ensure_one()
         account_ids = self._ponto_get_account_ids()
@@ -250,21 +193,10 @@ class OnlineBankStatementProviderPonto(models.Model):
             raise UserError(
                 _('Ponto : wrong configuration, unknow account %s')
                 % journal.bank_account_id.acc_number)
-        #
-        #Add function to collect ending balance
-        #
-        self._ponto_synchronisation_account_details(account_id, 'accountDetails')
-        balance_end_real = self._ponto_get_account_endind_balance(
-            account_id, date_since, date_until)
-        #
         self._ponto_synchronisation(account_id)
         transaction_lines = self._ponto_get_transaction(
             account_id, date_since, date_until)
         new_transactions = []
-        #
-        #Add variable balance_start that will be compute with transaction_lines
-        #
-        balance_start = balance_end_real
         sequence = 0
         for transaction in transaction_lines:
             sequence += 1
@@ -284,18 +216,11 @@ class OnlineBankStatementProviderPonto(models.Model):
                 'unique_import_id': transaction['id'],
                 'amount': attributes['amount'],
             }
-            #
-            #Compute balance start from balance_end_real and transaction amount
-            #
-            balance_start -= attributes['amount']
             if attributes.get("counterpartReference"):
                 vals_line["account_number"] = attributes["counterpartReference"]
             if attributes.get("counterpartName"):
                 vals_line["partner_name"] = attributes["counterpartName"]
             new_transactions.append(vals_line)
         if new_transactions:
-            new_transactions.append({
-            'balance_end_real': balance_end_real,
-            'balance_start': balance_start})
             return new_transactions, {}
         return

--- a/account_bank_statement_import_online_ponto/view/online_bank_statement_provider.xml
+++ b/account_bank_statement_import_online_ponto/view/online_bank_statement_provider.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account_bank_statement_import_online.online_bank_statement_provider_form"/>
         <field name="arch" type="xml">
             <xpath expr="//page[@name='configuration']" position="inside">
-                <group name="qonto" attrs="{'invisible':[('service','!=','ponto')]}">
+                <group name="ponto" attrs="{'invisible':[('service','!=','ponto')]}">
                     <field name="username" string="Login"/>
                     <field name="password" string="Secret Key"/>
                     <field name="ponto_last_identifier"/>

--- a/account_bank_statement_import_online_qonto/i18n/fr_FR.po
+++ b/account_bank_statement_import_online_qonto/i18n/fr_FR.po
@@ -1,0 +1,70 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_import_online_qonto
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_import_online_qonto
+#: code:addons/account_bank_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py:63
+#: code:addons/account_bank_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py:92
+#, python-format
+msgid ""
+"%s \n"
+"\n"
+" %s"
+msgstr ""
+"%s \n"
+"\n"
+" %s"
+
+#. module: account_bank_statement_import_online_qonto
+#: code:addons/account_bank_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py:115
+#, python-format
+msgid "Currency %s used in transaction ID %s doesn't exist in Odoo."
+msgstr "La devise %s utilisée dans la Transaction ID %s n’existe pas dans Odoo."
+
+#. module: account_bank_statement_import_online_qonto
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_qonto.online_bank_statement_provider_form
+msgid "Key"
+msgstr "Clé"
+
+#. module: account_bank_statement_import_online_qonto
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_qonto.online_bank_statement_provider_form
+msgid "Login"
+msgstr "Identifiant"
+
+#. module: account_bank_statement_import_online_qonto
+#: model:ir.model,name:account_bank_statement_import_online_qonto.model_online_bank_statement_provider
+msgid "Online Bank Statement Provider"
+msgstr "Fournisseur de relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online_qonto
+#: code:addons/account_bank_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py:50
+#, python-format
+msgid "Please fill login and key"
+msgstr "S’il vous plaît remplir le login et la clé"
+
+#. module: account_bank_statement_import_online_qonto
+#: code:addons/account_bank_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py:138
+#, python-format
+msgid "Qonto : wrong configuration, unknow account %s"
+msgstr "Qonto : mauvaise configuration, compte inconnu %s"
+
+#. module: account_bank_statement_import_online_qonto
+#: code:addons/account_bank_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py:111
+#, python-format
+msgid "Transaction ID %s has not local_currency. This should never happen."
+msgstr "La transaction ID %s n’a pas de devise. Ça ne devrait jamais arriver."

--- a/account_bank_statement_import_online_transferwise/i18n/fr_FR.po
+++ b/account_bank_statement_import_online_transferwise/i18n/fr_FR.po
@@ -1,0 +1,62 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_import_online_transferwise
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_import_online_transferwise
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_transferwise.online_bank_statement_provider_form
+msgid "API base"
+msgstr "API Base"
+
+#. module: account_bank_statement_import_online_transferwise
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_transferwise.online_bank_statement_provider_form
+msgid "API key"
+msgstr "Clé API"
+
+#. module: account_bank_statement_import_online_transferwise
+#: code:addons/account_bank_statement_import_online_transferwise/models/online_bank_statement_provider_transferwise.py:131
+#, python-format
+msgid "Ending balance unavailable"
+msgstr "Solde final indisponible"
+
+#. module: account_bank_statement_import_online_transferwise
+#: code:addons/account_bank_statement_import_online_transferwise/models/online_bank_statement_provider_transferwise.py:250
+#, python-format
+msgid "Fee for %s"
+msgstr "Frais pour %s"
+
+#. module: account_bank_statement_import_online_transferwise
+#: code:addons/account_bank_statement_import_online_transferwise/models/online_bank_statement_provider_transferwise.py:281
+#, python-format
+msgid "No API key specified!"
+msgstr "Aucune clé API spécifiée !"
+
+#. module: account_bank_statement_import_online_transferwise
+#: model:ir.model,name:account_bank_statement_import_online_transferwise.model_online_bank_statement_provider
+msgid "Online Bank Statement Provider"
+msgstr "Fournisseur de relevés bancaires en ligne"
+
+#. module: account_bank_statement_import_online_transferwise
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_online_transferwise.online_bank_statement_provider_form
+msgid "Profile"
+msgstr "Profil"
+
+#. module: account_bank_statement_import_online_transferwise
+#: code:addons/account_bank_statement_import_online_transferwise/models/online_bank_statement_provider_transferwise.py:255
+#, python-format
+msgid "Transaction fee for %s"
+msgstr "Frais de transaction pour %s"

--- a/account_bank_statement_import_paypal/i18n/fr_FR.po
+++ b/account_bank_statement_import_paypal/i18n/fr_FR.po
@@ -1,0 +1,345 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_import_paypal
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__balance_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__balance_column
+msgid "\"Balance\" column"
+msgstr "Colonne « Equilibre »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__bank_account_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__bank_account_column
+msgid "\"Bank Account\" column"
+msgstr "Colonne « Compte bancaire »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__bank_name_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__bank_name_column
+msgid "\"Bank Name\" column"
+msgstr "Colonne « Nom de banque »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__currency_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__currency_column
+msgid "\"Currency\" column"
+msgstr "Colonne « Monnaie »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__date_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__date_column
+msgid "\"Date\" column"
+msgstr "Colonne « Date »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__description_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__description_column
+msgid "\"Description\" column"
+msgstr "Colonne « Description »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__fee_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__fee_column
+msgid "\"Fee\" column"
+msgstr "Colonne « Frais »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__from_email_address_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__from_email_address_column
+msgid "\"From Email Address\" column"
+msgstr "Colonne « À partir de l’adresse e-mail »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__gross_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__gross_column
+msgid "\"Gross\" column"
+msgstr "Colonne « Brute »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__invoice_id_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__invoice_id_column
+msgid "\"Invoice ID\" column"
+msgstr "Colonne « Id facture »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__name_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__name_column
+msgid "\"Name\" column"
+msgstr "Colonne « Nom »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__note_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__note_column
+msgid "\"Note\" column"
+msgstr "Colonne « Note »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__subject_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__subject_column
+msgid "\"Subject\" column"
+msgstr "Colonne « Sujet »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__time_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__time_column
+msgid "\"Time\" column"
+msgstr "Colonne « Temps »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__tz_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__tz_column
+msgid "\"Timezone\" column"
+msgstr "Colonne « Fuseau horaire »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__to_email_address_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__to_email_address_column
+msgid "\"To Email Address\" column"
+msgstr "Colonne « À l’adresse e-mail »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__transaction_id_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__transaction_id_column
+msgid "\"Transaction ID\" column"
+msgstr "Colonne « Transaction ID »"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__type_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__type_column
+msgid "\"Type\" column"
+msgstr "Colonne « Type »"
+
+#. module: account_bank_statement_import_paypal
+#: code:addons/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_parser.py:43
+#, python-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model,name:account_bank_statement_import_paypal.model_account_bank_statement_import_paypal_mapping
+msgid "Account Bank Statement Import PayPal Mapping"
+msgstr "Correspondance des relevés bancaires PayPal"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model,name:account_bank_statement_import_paypal.model_account_bank_statement_import_paypal_mapping_wizard
+msgid "Account Bank Statement Import PayPal Mapping Wizard"
+msgstr "Utilitaire de correspondance des relevés de comptes Paypal"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model,name:account_bank_statement_import_paypal.model_account_bank_statement_import_paypal_parser
+msgid "Account Bank Statement Import PayPal Parser"
+msgstr "Analyseur de relevé de compte Paypal"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__allow_back
+msgid "Allow Back"
+msgstr "Autoriser le retour"
+
+#. module: account_bank_statement_import_paypal
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_paypal.account_bank_statement_import_paypal_mapping_wizard_form
+msgid "Choose a file to import..."
+msgstr "Choisissez un fichier à importer..."
+
+#. module: account_bank_statement_import_paypal
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_paypal.account_bank_statement_import_paypal_mapping_tree
+msgid "Columns"
+msgstr "Colonnes"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__create_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__create_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_parser__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__create_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__create_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_parser__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__date_format
+msgid "Date Format"
+msgstr "Format de date"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__float_decimal_sep
+msgid "Decimals Separator"
+msgstr "Séparateur Décimales"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__display_name
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__display_name
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_parser__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: account_bank_statement_import_paypal
+#: code:addons/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_parser.py:253
+#, python-format
+msgid "Fee for %s"
+msgstr "Frais pour %s"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__filename
+msgid "Filename"
+msgstr "Nom du fichier"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__header
+msgid "Header"
+msgstr "En-tête"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__id
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__id
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_parser__id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_bank_statement_import_paypal
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_paypal.account_bank_statement_import_paypal_mapping_wizard_form
+msgid "Import"
+msgstr "Importer"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model,name:account_bank_statement_import_paypal.model_account_bank_statement_import
+msgid "Import Bank Statement"
+msgstr "Importer le relevé bancaire CSV"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.actions.act_window,name:account_bank_statement_import_paypal.action_account_bank_statement_import_paypal_mapping_wizard
+msgid "Import Mapping"
+msgstr "Importer la configuration/ mapping"
+
+#. module: account_bank_statement_import_paypal
+#: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal_mapping_wizard.py:162
+#, python-format
+msgid "Imported Mapping"
+msgstr "Correspondance importée"
+
+#. module: account_bank_statement_import_paypal
+#: code:addons/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_parser.py:219
+#, python-format
+msgid "Invoice %s"
+msgstr "Facture %s"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model,name:account_bank_statement_import_paypal.model_account_journal
+msgid "Journal"
+msgstr "Journal"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping____last_update
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard____last_update
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_parser____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__write_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__write_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_parser__write_uid
+msgid "Last Updated by"
+msgstr "Dernière modification par"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__write_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__write_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_parser__write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: account_bank_statement_import_paypal
+#: code:addons/account_bank_statement_import_paypal/wizards/account_bank_statement_import_paypal_mapping_wizard.py:130
+#, python-format
+msgid "Mapping from %s"
+msgstr "Correspondance à partir de %s"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__name
+msgid "Name"
+msgstr "Nom"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__data_file
+msgid "PayPal Report File"
+msgstr "Fichier de Rapport PayPal"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.actions.act_window,name:account_bank_statement_import_paypal.action_statement_import_paypal_report_mappings
+#: model:ir.ui.menu,name:account_bank_statement_import_paypal.menu_statement_import_paypal_mapping
+msgid "PayPal Report Mappings"
+msgstr "Rapport de correspondances PayPal"
+
+#. module: account_bank_statement_import_paypal
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_paypal.account_bank_statement_import_view
+msgid "PayPal Report mapping:"
+msgstr "Rapport de correspondance PayPal :"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import__paypal_mapping_id
+msgid "PayPal mapping"
+msgstr "Correspondances PayPal"
+
+#. module: account_bank_statement_import_paypal
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_paypal.account_bank_statement_import_paypal_mapping_wizard_form
+msgid "Select a PayPal report file to import mapping."
+msgstr "Sélectionnez un fichier de rapport PayPal pour l’importer."
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__state
+msgid "State"
+msgstr "État"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__float_thousands_sep
+msgid "Thousands Separator"
+msgstr "Séparateur des milliers"
+
+#. module: account_bank_statement_import_paypal
+#: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__time_format
+msgid "Time Format"
+msgstr "Format de l'heure"
+
+#. module: account_bank_statement_import_paypal
+#: code:addons/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_parser.py:258
+#, python-format
+msgid "Transaction fee for %s"
+msgstr "Frais de transaction pour %s"
+
+#. module: account_bank_statement_import_paypal
+#: selection:account.bank.statement.import.paypal.mapping,float_decimal_sep:0
+#: selection:account.bank.statement.import.paypal.mapping,float_thousands_sep:0
+msgid "comma (,)"
+msgstr "virgule (,)"
+
+#. module: account_bank_statement_import_paypal
+#: selection:account.bank.statement.import.paypal.mapping,float_decimal_sep:0
+#: selection:account.bank.statement.import.paypal.mapping,float_thousands_sep:0
+msgid "dot (.)"
+msgstr "point (.)"
+
+#. module: account_bank_statement_import_paypal
+#: selection:account.bank.statement.import.paypal.mapping,float_decimal_sep:0
+#: selection:account.bank.statement.import.paypal.mapping,float_thousands_sep:0
+msgid "none"
+msgstr "aucune"

--- a/account_bank_statement_import_paypal/i18n/fr_FR.po
+++ b/account_bank_statement_import_paypal/i18n/fr_FR.po
@@ -21,7 +21,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__balance_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__balance_column
 msgid "\"Balance\" column"
-msgstr "Colonne « Equilibre »"
+msgstr "Colonne « Solde »"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__bank_account_column
@@ -33,13 +33,13 @@ msgstr "Colonne « Compte bancaire »"
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__bank_name_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__bank_name_column
 msgid "\"Bank Name\" column"
-msgstr "Colonne « Nom de banque »"
+msgstr "Colonne « Nom de la banque »"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__currency_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__currency_column
 msgid "\"Currency\" column"
-msgstr "Colonne « Monnaie »"
+msgstr "Colonne « Devise »"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__date_column
@@ -75,7 +75,7 @@ msgstr "Colonne « Brute »"
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__invoice_id_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__invoice_id_column
 msgid "\"Invoice ID\" column"
-msgstr "Colonne « Id facture »"
+msgstr "Colonne « ID facture »"
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__name_column

--- a/account_bank_statement_import_paypal/i18n/fr_FR.po
+++ b/account_bank_statement_import_paypal/i18n/fr_FR.po
@@ -21,109 +21,109 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__balance_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__balance_column
 msgid "\"Balance\" column"
-msgstr "Colonne « Solde »"
+msgstr "Colonne \"Solde\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__bank_account_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__bank_account_column
 msgid "\"Bank Account\" column"
-msgstr "Colonne « Compte bancaire »"
+msgstr "Colonne \"Compte bancaire\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__bank_name_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__bank_name_column
 msgid "\"Bank Name\" column"
-msgstr "Colonne « Nom de la banque »"
+msgstr "Colonne \"Nom de la banque\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__currency_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__currency_column
 msgid "\"Currency\" column"
-msgstr "Colonne « Devise »"
+msgstr "Colonne \"Devise\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__date_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__date_column
 msgid "\"Date\" column"
-msgstr "Colonne « Date »"
+msgstr "Colonne \"Date\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__description_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__description_column
 msgid "\"Description\" column"
-msgstr "Colonne « Description »"
+msgstr "Colonne \"Description\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__fee_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__fee_column
 msgid "\"Fee\" column"
-msgstr "Colonne « Frais »"
+msgstr "Colonne \"Frais\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__from_email_address_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__from_email_address_column
 msgid "\"From Email Address\" column"
-msgstr "Colonne « À partir de l’adresse e-mail »"
+msgstr "Colonne \"adresse e-mail réception\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__gross_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__gross_column
 msgid "\"Gross\" column"
-msgstr "Colonne « Brute »"
+msgstr "Colonne \"Brute\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__invoice_id_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__invoice_id_column
 msgid "\"Invoice ID\" column"
-msgstr "Colonne « ID facture »"
+msgstr "Colonne \"ID facture\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__name_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__name_column
 msgid "\"Name\" column"
-msgstr "Colonne « Nom »"
+msgstr "Colonne \"Nom\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__note_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__note_column
 msgid "\"Note\" column"
-msgstr "Colonne « Note »"
+msgstr "Colonne \"Note\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__subject_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__subject_column
 msgid "\"Subject\" column"
-msgstr "Colonne « Sujet »"
+msgstr "Colonne \"Sujet\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__time_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__time_column
 msgid "\"Time\" column"
-msgstr "Colonne « Temps »"
+msgstr "Colonne \"Temps\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__tz_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__tz_column
 msgid "\"Timezone\" column"
-msgstr "Colonne « Fuseau horaire »"
+msgstr "Colonne \"Fuseau horaire\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__to_email_address_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__to_email_address_column
 msgid "\"To Email Address\" column"
-msgstr "Colonne « À l’adresse e-mail »"
+msgstr "Colonne \"adresse e-mail destination\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__transaction_id_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__transaction_id_column
 msgid "\"Transaction ID\" column"
-msgstr "Colonne « Transaction ID »"
+msgstr "Colonne \"Transaction ID\""
 
 #. module: account_bank_statement_import_paypal
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping__type_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_paypal.field_account_bank_statement_import_paypal_mapping_wizard__type_column
 msgid "\"Type\" column"
-msgstr "Colonne « Type »"
+msgstr "Colonne \"Type\""
 
 #. module: account_bank_statement_import_paypal
 #: code:addons/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_parser.py:43

--- a/account_bank_statement_import_split/i18n/fr_FR.po
+++ b/account_bank_statement_import_split/i18n/fr_FR.po
@@ -1,0 +1,53 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_import_split
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_import_split
+#: selection:account.bank.statement.import,import_mode:0
+msgid "Daily statements"
+msgstr "Relevés quotidiens"
+
+#. module: account_bank_statement_import_split
+#: model:ir.model,name:account_bank_statement_import_split.model_account_bank_statement_import
+msgid "Import Bank Statement"
+msgstr "Importer le relevé bancaire CSV"
+
+#. module: account_bank_statement_import_split
+#: model:ir.model.fields,field_description:account_bank_statement_import_split.field_account_bank_statement_import__import_mode
+msgid "Import Mode"
+msgstr "Mode d’importation"
+
+#. module: account_bank_statement_import_split
+#: selection:account.bank.statement.import,import_mode:0
+msgid "Monthly statements"
+msgstr "Relevés mensuels"
+
+#. module: account_bank_statement_import_split
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_split.account_bank_statement_import_view
+msgid "Please select how you'd like to split the imported statement file:"
+msgstr "Veuillez sélectionner la façon dont vous souhaitez diviser le fichier de relevé importé :"
+
+#. module: account_bank_statement_import_split
+#: selection:account.bank.statement.import,import_mode:0
+msgid "Single statement"
+msgstr "Relevé unique"
+
+#. module: account_bank_statement_import_split
+#: selection:account.bank.statement.import,import_mode:0
+msgid "Weekly statements"
+msgstr "Relevés hebdomadaires"

--- a/account_bank_statement_import_txt_xlsx/i18n/fr_FR.po
+++ b/account_bank_statement_import_txt_xlsx/i18n/fr_FR.po
@@ -1,0 +1,543 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_bank_statement_import_txt_xlsx
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Pascal GOUHIER <p.gouhier@khetys.fr>\n"
+"Language: fr_FR\n"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: code:addons/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py:55
+#, python-format
+msgid "%s: %s"
+msgstr "%s: %s"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model,name:account_bank_statement_import_txt_xlsx.model_account_bank_statement_import_sheet_mapping
+msgid "Account Bank Statement Import Sheet Mapping"
+msgstr "Correspondance des relevés bancaires"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model,name:account_bank_statement_import_txt_xlsx.model_account_bank_statement_import_sheet_mapping_wizard
+msgid "Account Bank Statement Import Sheet Mapping Wizard"
+msgstr ""
+"Assistant de cartographie de feuille d’importation de relevé bancaire de "
+"compte"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model,name:account_bank_statement_import_txt_xlsx.model_account_bank_statement_import_sheet_parser
+msgid "Account Bank Statement Import Sheet Parser"
+msgstr "Analyseur de relevé de compte bancaire"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: code:addons/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py:306
+#, python-format
+msgid "Account: %s; "
+msgstr "Compte: %s; "
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__allow_back
+msgid "Allow Back"
+msgstr "Autoriser le retour"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__amount_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__amount_column
+msgid "Amount column"
+msgstr "Colonne « montant »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__amount_column
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__amount_column
+msgid "Amount of transaction in journal's currency"
+msgstr "Montant de la transaction dans la devise du journal"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__balance_column
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__balance_column
+msgid "Balance after transaction in journal's currency"
+msgstr "Solde après transaction dans la devise du journal"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__balance_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__balance_column
+msgid "Balance column"
+msgstr "Colonne « Equilibre »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Baltic (Latin-4 / ISO 8859-4)"
+msgstr "Baltique (Latin-4 / ISO 8859-4)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__bank_account_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__bank_account_column
+msgid "Bank Account column"
+msgstr "Colonne « Compte bancaire »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__bank_name_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__bank_name_column
+msgid "Bank Name column"
+msgstr "Colonne « Nom de banque »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__data_file
+msgid "Bank Statement File"
+msgstr "Fichier de relevé bancaire"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: code:addons/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py:302
+#, python-format
+msgid "Bank: %s; "
+msgstr "Banque: %s; "
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Central European (Latin-2 / ISO 8859-2)"
+msgstr "Europe centrale (Latin-2 / ISO 8859-2)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_sheet_mapping_wizard_form
+msgid "Choose a file to import..."
+msgstr "Choisissez un fichier à importer..."
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_sheet_mapping_tree
+msgid "Columns"
+msgstr "Colonnes"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__create_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__create_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_parser__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__create_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__create_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_parser__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__credit_value
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__credit_value
+msgid "Credit value"
+msgstr "Crédit"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__currency_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__currency_column
+msgid "Currency column"
+msgstr "Colonne « Devise »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Cyrillic (KOI8-R)"
+msgstr "Cyrillique (KOI8-R)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Cyrillic (KOI8-U)"
+msgstr "Cyrillique (KOI8-U)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Cyrillic (Windows-1251)"
+msgstr "Cyrillique (Windows-1251)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__debit_value
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__debit_value
+msgid "Debit value"
+msgstr "Débit"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_sheet_mapping_wizard_form
+msgid "Debit/Credit column"
+msgstr "Colonne débit/crédit"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__debit_credit_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__debit_credit_column
+msgid "Debit/credit column"
+msgstr "Colonne débit/crédit"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__float_decimal_sep
+msgid "Decimals Separator"
+msgstr "Séparateur Décimales"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_journal_creation__default_sheet_mapping_id
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_journal__default_sheet_mapping_id
+msgid "Default Sheet Mapping"
+msgstr "Correspondance par défaut"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__delimiter
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__delimiter
+msgid "Delimiter"
+msgstr "Délimiteur"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__description_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__description_column
+msgid "Description column"
+msgstr "Colonne « Description »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__display_name
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__display_name
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_parser__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__file_encoding
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__file_encoding
+msgid "Encoding"
+msgstr "Encodage"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__filename
+msgid "Filename"
+msgstr "Nom du fichier"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__header
+msgid "Header"
+msgstr "En-tête"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__id
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__id
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_parser__id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_sheet_mapping_wizard_form
+msgid "Import"
+msgstr "Importer"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model,name:account_bank_statement_import_txt_xlsx.model_account_bank_statement_import
+msgid "Import Bank Statement"
+msgstr "Importer le relevé bancaire CSV"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.actions.act_window,name:account_bank_statement_import_txt_xlsx.action_account_bank_statement_import_sheet_mapping_wizard
+msgid "Import Mapping"
+msgstr "Importer la configuration/ mapping"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: code:addons/account_bank_statement_import_txt_xlsx/wizards/account_bank_statement_import_sheet_mapping_wizard.py:185
+#, python-format
+msgid "Imported Mapping"
+msgstr "Correspondance importée"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__currency_column
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__currency_column
+msgid ""
+"In case statement is multi-currency, column to get currency of transaction "
+"from"
+msgstr ""
+"Dans le cas où le relevé est multi-devises, colonne pour obtenir la devise "
+"de la transaction de"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__original_currency_column
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__original_currency_column
+msgid ""
+"In case statement provides original currency for transactions with automatic "
+"currency conversion, column to get original currency of transaction from"
+msgstr ""
+"Dans le cas où le relevé fournit la devise originale pour les transactions "
+"avec conversion automatique de devise, colonne pour obtenir la devise "
+"originale de la transaction de"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__original_amount_column
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__original_amount_column
+msgid ""
+"In case statement provides original currency for transactions with automatic "
+"currency conversion, column to get original transaction amount in original "
+"transaction currency from"
+msgstr ""
+"Dans le cas où le relevé fournit la devise originale pour les transactions "
+"avec conversion automatique de devise, colonne pour obtenir le montant "
+"original de transaction dans la devise originale de transaction de"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Japanese (Shift JIS)"
+msgstr "Japonais (Shift JIS)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model,name:account_bank_statement_import_txt_xlsx.model_account_journal
+msgid "Journal"
+msgstr "Journal"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping____last_update
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard____last_update
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_parser____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__write_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__write_uid
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_parser__write_uid
+msgid "Last Updated by"
+msgstr "Dernière modification par"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__write_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__write_date
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_parser__write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: code:addons/account_bank_statement_import_txt_xlsx/wizards/account_bank_statement_import_sheet_mapping_wizard.py:153
+#, python-format
+msgid "Mapping from %s"
+msgstr "Correspondance à partir de %s"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,delimiter:0
+#: code:addons/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py:296
+#, python-format
+msgid "N/A"
+msgstr "N/A"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__name
+msgid "Name"
+msgstr "Nom"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__notes_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__notes_column
+msgid "Notes column"
+msgstr "Colonne « Note »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_sheet_mapping_wizard_form
+msgid "Options"
+msgstr "Options"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__original_amount_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__original_amount_column
+msgid "Original amount column"
+msgstr "Colonne « montant d’origine »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__original_currency_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__original_currency_column
+msgid "Original currency column"
+msgstr "Colonne « devise originale »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__partner_name_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__partner_name_column
+msgid "Partner Name column"
+msgstr "Colonne « nom du partenaire »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__bank_name_column
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__bank_name_column
+msgid "Partner's bank"
+msgstr "Banque du partenaire"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__bank_account_column
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__bank_account_column
+msgid "Partner's bank account"
+msgstr "Compte bancaire du partenaire"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__reference_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__reference_column
+msgid "Reference column"
+msgstr "Colonne « Référence »"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_sheet_mapping_wizard_form
+msgid "Select a statement file to import mapping"
+msgstr "Sélectionnez un fichier de relevé pour l’import"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import__sheet_mapping_id
+msgid "Sheet mapping"
+msgstr "Feuille de correspondance"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__debit_credit_column
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__debit_credit_column
+msgid ""
+"Some statement formats use absolute amount value and indicate signof the "
+"transaction by specifying if it was a debit or a credit one"
+msgstr ""
+"Certains formats de relevé utilisent la valeur du montant absolu et "
+"indiquent le signe de la transaction en précisant s’il s’agissait d’un débit "
+"ou d’un crédit"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__state
+msgid "State"
+msgstr "État"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.view_account_journal_form_n43
+msgid "Statement Import Map"
+msgstr "Carte d’importation des relevés"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.actions.act_window,name:account_bank_statement_import_txt_xlsx.action_statement_import_sheet_report_mappings
+#: model:ir.ui.menu,name:account_bank_statement_import_txt_xlsx.menu_statement_import_sheet_mapping
+msgid "Statement Sheet Mappings"
+msgstr "Correspondances de champ"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_view
+msgid "TXT/CSV/XLSX mapping:"
+msgstr "Correspondance TXT/CSV/XLSX :"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__quotechar
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__quotechar
+msgid "Text qualifier"
+msgstr "Séparateur de chaine de caractère"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__float_thousands_sep
+msgid "Thousands Separator"
+msgstr "Séparateur des milliers"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__timestamp_format
+msgid "Timestamp Format"
+msgstr "Format de l’horadatage"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__timestamp_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__timestamp_column
+msgid "Timestamp column"
+msgstr "Colonne d'horodatage"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Traditional Chinese (big5)"
+msgstr "Chinois traditionnel (big5)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: code:addons/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py:310
+#, python-format
+msgid "Transaction ID: %s; "
+msgstr "Transaction ID: %s; "
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "UTF-16"
+msgstr "UTF-16"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "UTF-16 (with BOM)"
+msgstr "UTF-16 (avec BOM)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "UTF-8"
+msgstr "UTF-8 (en)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "UTF-8 (with BOM)"
+msgstr "UTF-8 (avec BOM)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Unified Chinese (gb18030)"
+msgstr "Chinois unifié (gb18030)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__transaction_id_column
+#: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__transaction_id_column
+msgid "Unique transaction ID column"
+msgstr "Colonne ID de transaction unique"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__credit_value
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__credit_value
+msgid "Value of debit/credit column that indicates if it's a credit"
+msgstr "Valeur de la colonne débit/crédit qui indique s’il s’agit d’un crédit"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__debit_value
+#: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__debit_value
+msgid "Value of debit/credit column that indicates if it's a debit"
+msgstr "Valeur de la colonne débit/crédit qui indique s’il s’agit d’un débit"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Western (Latin-1 / ISO 8859-1)"
+msgstr "Occidental (Latin-1 / ISO 8859-1)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
+msgid "Western (Windows-1252)"
+msgstr "Occidental (Windows-1252)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,delimiter:0
+#: selection:account.bank.statement.import.sheet.mapping,float_decimal_sep:0
+#: selection:account.bank.statement.import.sheet.mapping,float_thousands_sep:0
+msgid "comma (,)"
+msgstr "virgule (,)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,delimiter:0
+#: selection:account.bank.statement.import.sheet.mapping,float_decimal_sep:0
+#: selection:account.bank.statement.import.sheet.mapping,float_thousands_sep:0
+msgid "dot (.)"
+msgstr "point (.)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,float_decimal_sep:0
+#: selection:account.bank.statement.import.sheet.mapping,float_thousands_sep:0
+msgid "none"
+msgstr "aucune"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,delimiter:0
+msgid "semicolon (;)"
+msgstr "point-virgule (;)"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,delimiter:0
+msgid "space"
+msgstr "espace"
+
+#. module: account_bank_statement_import_txt_xlsx
+#: selection:account.bank.statement.import.sheet.mapping,delimiter:0
+msgid "tab"
+msgstr "tabulation"

--- a/account_bank_statement_import_txt_xlsx/i18n/fr_FR.po
+++ b/account_bank_statement_import_txt_xlsx/i18n/fr_FR.po
@@ -55,7 +55,7 @@ msgstr "Autoriser le retour"
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__amount_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__amount_column
 msgid "Amount column"
-msgstr "Colonne « montant »"
+msgstr "Colonne \"montant\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__amount_column
@@ -73,7 +73,7 @@ msgstr "Solde après transaction dans la devise du journal"
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__balance_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__balance_column
 msgid "Balance column"
-msgstr "Colonne « Equilibre »"
+msgstr "Colonne \"Equilibre\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
@@ -84,13 +84,13 @@ msgstr "Baltique (Latin-4 / ISO 8859-4)"
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__bank_account_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__bank_account_column
 msgid "Bank Account column"
-msgstr "Colonne « Compte bancaire »"
+msgstr "Colonne \"Compte bancaire\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__bank_name_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__bank_name_column
 msgid "Bank Name column"
-msgstr "Colonne « Nom de banque »"
+msgstr "Colonne \"Nom de banque\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__data_file
@@ -142,7 +142,7 @@ msgstr "Crédit"
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__currency_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__currency_column
 msgid "Currency column"
-msgstr "Colonne « Devise »"
+msgstr "Colonne \"Devise\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: selection:account.bank.statement.import.sheet.mapping,file_encoding:0
@@ -197,7 +197,7 @@ msgstr "Délimiteur"
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__description_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__description_column
 msgid "Description column"
-msgstr "Colonne « Description »"
+msgstr "Colonne \"Description\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__display_name
@@ -336,7 +336,7 @@ msgstr "Nom"
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__notes_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__notes_column
 msgid "Notes column"
-msgstr "Colonne « Note »"
+msgstr "Colonne \"Note\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_sheet_mapping_wizard_form
@@ -347,19 +347,19 @@ msgstr "Options"
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__original_amount_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__original_amount_column
 msgid "Original amount column"
-msgstr "Colonne « montant d’origine »"
+msgstr "Colonne \"montant d’origine\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__original_currency_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__original_currency_column
 msgid "Original currency column"
-msgstr "Colonne « devise originale »"
+msgstr "Colonne \"devise originale\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__partner_name_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__partner_name_column
 msgid "Partner Name column"
-msgstr "Colonne « nom du partenaire »"
+msgstr "Colonne \"nom du partenaire\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model:ir.model.fields,help:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__bank_name_column
@@ -377,7 +377,7 @@ msgstr "Compte bancaire du partenaire"
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping__reference_column
 #: model:ir.model.fields,field_description:account_bank_statement_import_txt_xlsx.field_account_bank_statement_import_sheet_mapping_wizard__reference_column
 msgid "Reference column"
-msgstr "Colonne « Référence »"
+msgstr "Colonne \"Référence\""
 
 #. module: account_bank_statement_import_txt_xlsx
 #: model_terms:ir.ui.view,arch_db:account_bank_statement_import_txt_xlsx.account_bank_statement_import_sheet_mapping_wizard_form


### PR DESCRIPTION
Traduction française des modules
Correction de la vue des services : pour Ponto, c'était qonto qui était affiché.