### PR TITLE
[14.0][FIX] avoid conflict with enterprise module account_bank_statement_import

### DIFF
--- a/account_statement_import/models/account_journal.py
+++ b/account_statement_import/models/account_journal.py
@@ -22,7 +22,7 @@ class AccountJournal(models.Model):
             rslt.append(("file_import", _("Import") + "(" + import_formats_str + ")"))
         return rslt
 
-    def import_statement(self):
+    def import_account_statement(self):
         """return action to import bank/cash statements.
         This button should be called only on journals with type =='bank'"""
         action = (

--- a/account_statement_import/views/account_journal.xml
+++ b/account_statement_import/views/account_journal.xml
@@ -12,11 +12,17 @@
         <field name="inherit_id" ref="account.account_journal_dashboard_kanban_view" />
         <field name="arch" type="xml">
             <xpath expr='//span[@name="button_import_placeholder"]' position='inside'>
-                <span>or <a type="object" name="import_statement">Import</a></span>
+                <span>or <a
+                        type="object"
+                        name="import_account_statement"
+                    >Import</a></span>
             </xpath>
             <xpath expr='//div[@name="bank_cash_commands"]' position="before">
                 <div t-if="journal_type == 'bank'">
-                    <a type="object" name="import_statement">Import Statement</a>
+                    <a
+                        type="object"
+                        name="import_account_statement"
+                    >Import Statement</a>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Modules OCA **account_statement_import** and ENTERPRISE **account_bank_statement_import** adds a link in **account.journal** that call the same method name **import_statement**. 
When user click any import button, the **import_statement** method of ENTERPRISE module is called.
This PR changes the name of the method in **account_statement_import** module to avoid conflict with ENTERPRISE one.