### PR TITLE
[13.0][FIX] absi- _camt_oca. Prevent recursion in exception handling

### DIFF
--- a/account_bank_statement_import_camt_oca/models/account_bank_statement_import.py
+++ b/account_bank_statement_import_camt_oca/models/account_bank_statement_import.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2016 Therp BV <https://therp.nl>
+# Copyright 2013-2021 Therp BV <https://therp.nl>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 import logging
 import zipfile
@@ -25,7 +25,7 @@ class AccountBankStatementImport(models.TransientModel):
                     account_number = None
                     transactions = []
                     for member in data.namelist():
-                        currency, account_number, new = self._parse_file(
+                        currency, account_number, new = parser.parse(
                             data.open(member).read()
                         )
                         transactions.extend(new)


### PR DESCRIPTION
Under certain conditions the _parse_file function for camt statements can be passed a file, for instance an excel spreadsheet, that it should not handle, but leave to another importer. The initial error will be caught and an attempt made to read the file as a camt zip file. As an excel file (and probably others) can be read as a zipfile, this leads to another exception that is not properly handled.

The problem is solved by not calling _parse_file recursively.