### PR TITLE
[14.0][FIX] account_statement_import_camt: Related a problem with Swiss CAMT54 files and missing currency.

### DIFF
--- a/account_statement_import_camt/models/parser.py
+++ b/account_statement_import_camt/models/parser.py
@@ -204,7 +204,7 @@ class CamtParser(models.AbstractModel):
         )
         self.add_value_from_node(ns, node, "./ns:Id", result, "name")
         self.add_value_from_node(
-            ns, node, ["./ns:Acct/ns:Ccy", "./ns:Bal/ns:Amt/@Ccy"], result, "currency"
+            ns, node, ["./ns:Acct/ns:Ccy", "./ns:Bal/ns:Amt/@Ccy", "./ns:Ntry/ns:Amt/@Ccy"], result, "currency"
         )
         result["balance_start"], result["balance_end_real"] = self.get_balance_amounts(
             ns, node


### PR DESCRIPTION
Currency is not required in Acct on swiss CAMT54 files, and in camt 54 the Bal element is missing.
I added the third option to look inside a Entry element.
The third option will be hit only if first two fail.

Without it it's throwing a Error (missing currency) on swiss CAMT54 ESR files.

https://github.com/OCA/bank-statement-import/issues/387