### PR TITLE
[14][account_statement_import][FIX] Error string formatting

### DIFF
--- a/account_statement_import/wizard/account_statement_import.py
+++ b/account_statement_import/wizard/account_statement_import.py
@@ -249,7 +249,7 @@ class AccountStatementImport(models.TransientModel):
                             "bank journal doesn't exist yet, you should create "
                             "a new one."
                         )
-                        % (account_number, company.partner_id.display_name)
+                        % (account_number,)
                     )
                 else:
                     raise UserError(


### PR DESCRIPTION
Fix error message when importing a file of an existing account, not linked to the journal.