### PR TITLE
[13.0][FIX] account_bank_statement_import_paypal: Parser bug for required fields

### DIFF
--- a/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_parser.py
+++ b/account_bank_statement_import_paypal/models/account_bank_statement_import_paypal_parser.py
@@ -72,7 +72,7 @@ class AccountBankStatementImportPayPalParser(models.TransientModel):
         )
 
     def _data_dict_constructor(self, mapping, header):
-        list_of_content = [
+        required_list = [
             "date_column",
             "time_column",
             "tz_column",
@@ -82,6 +82,8 @@ class AccountBankStatementImportPayPalParser(models.TransientModel):
             "fee_column",
             "balance_column",
             "transaction_id_column",
+        ]
+        optional_list = [
             "description_column",
             "type_column",
             "from_email_address_column",
@@ -93,7 +95,9 @@ class AccountBankStatementImportPayPalParser(models.TransientModel):
             "bank_account_column",
         ]
         data_dict = {}
-        for key in list_of_content:
+        for key in required_list:
+            data_dict[key] = header.index(getattr(mapping, key))
+        for key in optional_list:
             try:
                 data_dict[key] = header.index(getattr(mapping, key))
             except ValueError:


### PR DESCRIPTION
The fields required for the paypal parser are set as None and don't throw the
ValueError. With this changes we achieve to filter the data and throw the exception
when the fields are required.

cc @Tecnativa TT29944

please @joao-p-marques @pedrobaeza review this