### PR TITLE
[13.0][FIX] account_bank_statement_import_txt_xlsx: importing notes field

### DIFF
--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
@@ -350,9 +350,11 @@ class AccountBankStatementImportSheetParser(models.TransientModel):
         if transaction_id:
             note += _("Transaction ID: %s; ") % (transaction_id,)
         if note and notes:
-            note = "{}\n{}".format(note, note.strip())
+            note = "{}\n{}".format(notes, note.strip())
         elif note:
             note = note.strip()
+        elif notes:
+            note = notes
         if note:
             transaction["note"] = note
 


### PR DESCRIPTION
When importing a file with a "Notes" field, the field is not imported, despite having modified the Statement Sheet Mapping:
Excel file:
![image](https://user-images.githubusercontent.com/36236518/129048202-0e96b3d6-160a-4fc0-9e5e-1ce703ccede6.png)

Odoo importation:
![image](https://user-images.githubusercontent.com/36236518/129048617-ec140820-4d6b-4e0b-953f-3f6738d23461.png)

With the suggested change, the importation includes the "Notes" field:
![image](https://user-images.githubusercontent.com/36236518/129048386-4ee52646-3e0f-4d3e-9150-7991bb0d6102.png)

