### PR TITLE
[14.0][IMP] account_statement_import_online: don't import empty statements.

### DIFF
--- a/account_statement_import_online/README.rst
+++ b/account_statement_import_online/README.rst
@@ -56,6 +56,10 @@ or, alternatively:
 #. Save the bank account
 #. Click on provider and configure provider-specific settings.
 
+If you want to allow empty bank statements to be created every time the
+information is pulled, you can check the option "Allow empty statements"
+at the provider configuration level.
+
 **NOTE**: To access these features, user needs to belong to
 *Show Full Accounting Features* group.
 

--- a/account_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_statement_import_online/models/online_bank_statement_provider.py
@@ -95,6 +95,7 @@ class OnlineBankStatementProvider(models.Model):
     certificate_public_key = fields.Text()
     certificate_private_key = fields.Text()
     certificate_chain = fields.Text()
+    allow_empty_statements = fields.Boolean(string="Allow empty statements")
 
     _sql_constraints = [
         (
@@ -204,6 +205,8 @@ class OnlineBankStatementProvider(models.Model):
             )
         if not data:
             data = ([], {})
+        if not data[0] and not data[1] and not self.allow_empty_statements:
+            return
         lines_data, statement_values = data
         if not lines_data:
             lines_data = []

--- a/account_statement_import_online/readme/CONFIGURE.rst
+++ b/account_statement_import_online/readme/CONFIGURE.rst
@@ -19,5 +19,9 @@ or, alternatively:
 #. Save the bank account
 #. Click on provider and configure provider-specific settings.
 
+If you want to allow empty bank statements to be created every time the
+information is pulled, you can check the option "Allow empty statements"
+at the provider configuration level.
+
 **NOTE**: To access these features, user needs to belong to
 *Show Full Accounting Features* group.

--- a/account_statement_import_online/static/description/index.html
+++ b/account_statement_import_online/static/description/index.html
@@ -406,6 +406,9 @@ section</li>
 <li>Save the bank account</li>
 <li>Click on provider and configure provider-specific settings.</li>
 </ol>
+<p>If you want to allow empty bank statements to be created every time the
+information is pulled, you can check the option “Allow empty statements”
+at the provider configuration level.</p>
 <p><strong>NOTE</strong>: To access these features, user needs to belong to
 <em>Show Full Accounting Features</em> group.</p>
 </div>

--- a/account_statement_import_online/views/online_bank_statement_provider.xml
+++ b/account_statement_import_online/views/online_bank_statement_provider.xml
@@ -79,6 +79,7 @@
                         <group name="configuration" string="Configuration">
                             <field name="statement_creation_mode" />
                             <field name="tz" />
+                            <field name="allow_empty_statements" />
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
Cc @Tecnativa TT31034

Sometimes and depending on how the 'Statement Creation Mode' field is configured in the provider model, empty bank statements will be created. This PR is to avoid that.

Main changes:
- Avoid create empty statements.
- Add unit tests.