### PR TITLE
[FIX] account_bank_statement_import_online_paypal: timezone handling

### DIFF
--- a/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
+++ b/account_bank_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
@@ -277,6 +277,27 @@ class OnlineBankStatementProviderPayPal(models.Model):
             'balance_end_real': balance_end,
         }
 
+    @api.multi
+    def _get_statement_date_step(self):
+        delta = super()._get_statement_date_step()
+        if self.service == 'paypal':
+            delta.__dict__.update(
+                hour=None,
+                minute=None,
+                second=None,
+                microsecond=None,
+            )
+        return delta
+
+    @api.multi
+    def _get_statement_date_since(self, date):
+        date = super()._get_statement_date_since(date)
+        if self.service == 'paypal' and self.tz and not date.tzinfo:
+            date = pytz.timezone(self.tz).localize(date).astimezone(
+                pytz.utc
+            ).replace(tzinfo=None)
+        return date
+
     @api.model
     def _paypal_preparse_transaction(self, transaction):
         date = dateutil.parser.parse(


### PR DESCRIPTION
I had some issues with daily statements and hourly/daily (doesn't really matter) pulls:

In the [original functions](https://github.com/OCA/bank-statement-import/blob/12.0/account_bank_statement_import_online/models/online_bank_statement_provider.py#L323), all time information is nixed, so we effectively always request UTC times, which makes the statements imported in Odoo inconsistent with the reports you can look at on the website (you miss whatever is within your UTC+-N), which confuses users a lot, even though in the end, you get the correct balances.

What's the rationale to normalize in these functions at all? Can't we normalize `next_run` on input? `statement_date_since` needs to be adapted for the same reason.