### PR TITLE
[14.0] [IMP] account_statement_import_camt: unique statement names

### DIFF
--- a/account_statement_import_camt/__manifest__.py
+++ b/account_statement_import_camt/__manifest__.py
@@ -8,5 +8,8 @@
     "website": "https://github.com/OCA/bank-statement-import",
     "category": "Banking addons",
     "depends": ["account_statement_import"],
-    "data": ["views/account_bank_statement_import.xml"],
+    "data": [
+        "views/account_bank_statement_import.xml",
+        "views/res_config_settings.xml",
+    ],
 }

--- a/account_statement_import_camt/models/__init__.py
+++ b/account_statement_import_camt/models/__init__.py
@@ -1,3 +1,4 @@
+from . import res_config_settings
 from . import parser
 from . import account_bank_statement_line
 from . import account_statement_import

--- a/account_statement_import_camt/models/account_statement_import.py
+++ b/account_statement_import_camt/models/account_statement_import.py
@@ -5,6 +5,9 @@ import zipfile
 from io import BytesIO
 
 from odoo import models
+from odoo.exceptions import ValidationError
+
+from .res_config_settings import CHECKING_NAME_UNIQUE
 
 _logger = logging.getLogger(__name__)
 
@@ -35,3 +38,27 @@ class AccountBankStatementImport(models.TransientModel):
             # Not a camt file, returning super will call next candidate:
             _logger.debug("Statement file was not a camt file.", exc_info=True)
         return super()._parse_file(data_file)
+
+    def _check_parsed_data(self, stmts_vals):
+        """Check for unique statement name if config param is set."""
+        result = super()._check_parsed_data(stmts_vals)
+        config_param = self.env["ir.config_parameter"].sudo()
+        checking_name_unique = config_param.get_param(CHECKING_NAME_UNIQUE, False)
+        if not result or not checking_name_unique:
+            return result
+
+        def raise_error(message):
+            raise ValidationError(message + ", ".join(dup_names))
+
+        names = [v["name"] for v in stmts_vals]
+        name_set = set(names)
+        dup_names = {name for name in name_set if names.count(name) > 1}
+        if dup_names:
+            raise_error("Duplicated name in data file itself: ")
+
+        domain = [("name", "in", list(name_set))]
+        dup_records = self.env["account.bank.statement"].search(domain)
+        dup_names.update(dup_records.mapped("name"))
+        if dup_names:
+            raise_error("Bank statement must be unique: ")
+        return result

--- a/account_statement_import_camt/models/res_config_settings.py
+++ b/account_statement_import_camt/models/res_config_settings.py
@@ -1,0 +1,17 @@
+# Copyright 2021 CampToCamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+MODULE = "account_statement_import_camt"
+CHECKING_NAME_UNIQUE = MODULE + ".checking_bank_statement_name_unique"
+
+
+class ResConfigSetting(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    checking_bank_statement_name_unique = fields.Boolean(
+        string="Unique bank statement name",
+        config_parameter=CHECKING_NAME_UNIQUE,
+        default=False,
+    )

--- a/account_statement_import_camt/views/account_bank_statement_import.xml
+++ b/account_statement_import_camt/views/account_bank_statement_import.xml
@@ -11,6 +11,11 @@
                 <li>CAMT</li>
                 <li>zipped CAMT</li>
             </ul>
+            <ul id="statement_format" position="after">
+                <p
+                    id="checking_name_unique"
+                >Unique bank statement name checking (needed by CAMT importing) can be turned on at Settings > Invoicing > Bank Statement Import > Bank Statement Import.</p>
+            </ul>
         </field>
     </record>
 </odoo>

--- a/account_statement_import_camt/views/res_config_settings.xml
+++ b/account_statement_import_camt/views/res_config_settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_check_name_unique" model="ir.ui.view">
+        <field
+            name="name"
+        >account_bank_statement_import res.config.settings form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div id="print_vendor_checks_setting_container" position="after">
+                <h2>Bank Statement Import</h2>
+                <div class="row mt16 o_settings_container" id="bank_statement_import">
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="checking_bank_statement_name_unique" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="checking_bank_statement_name_unique" />
+                            <div class="text-muted">
+                                Bank statement name must be unique
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
* Most import formats provide unique transaction ids, which allows to
ensure no redundant import happens
(https://github.com/OCA/bank-statement-import/blob/14.0/account_statement_import/models/account_bank_statement_line.py#L14)
CAMT format doesn't, so we add a new feature to check for uniqueness at
the statement name level

* The block `Bank & Cash` is only visible to `group_account_user`
(https://github.com/odoo/odoo/blob/14.0/addons/account/views/res_config_settings_views.xml#L448).
But admin is `group_account_manager` so he cannot view the block
(https://github.com/odoo/odoo/blob/14.0/addons/account/security/account_security.xml#L25).
That is why `Bank Statement Import` block is added for new config
parameter.