### PR TITLE
PayPal import fails if there is number in details or description

### DIFF
--- a/account_statement_import_paypal/models/account_statement_import_paypal_parser.py
+++ b/account_statement_import_paypal/models/account_statement_import_paypal_parser.py
@@ -207,9 +207,9 @@ class AccountBankStatementImportPayPalParser(models.TransientModel):
             note += " (%s)" % payer_email
 
         unique_import_id = "{}-{}".format(transaction_id, int(timestamp.timestamp()))
-        name = (invoice or details or description or "",)
+        name = (invoice or transaction_id or "",)
         transaction = {
-            "name": invoice or details or description or "",
+            "name": name[0],
             "amount": str(gross_amount),
             "date": timestamp,
             "payment_ref": note,

--- a/account_statement_import_paypal/models/account_statement_import_paypal_parser.py
+++ b/account_statement_import_paypal/models/account_statement_import_paypal_parser.py
@@ -216,9 +216,9 @@ class AccountBankStatementImportPayPalParser(models.TransientModel):
             "unique_import_id": unique_import_id,
         }
         if payer_name:
-            line.update({"partner_name": payer_name})
+            transaction.update({"partner_name": payer_name})
         if partner_bank_account:
-            line.update({"account_number": partner_bank_account})
+            transaction.update({"account_number": partner_bank_account})
         transactions.append(transaction)
 
         if fee_amount:


### PR DESCRIPTION
The regex matches lines like "Some Caption 39 xx 30"
_sequence_yearly_regex = r'^(?P<prefix1>.*?)(?P<year>((?<=\D)|(?<=^))((19|20|21)?\d{2}))(?P<prefix2>\D+?)(?P<seq>\d*)(?P<suffix>\D*?)$'

The test in _constrains_date_sequence fails and a ValidationError is thrown.

The other patch adds the data to the new transaction and does not update the source data.