### PR TITLE
[14.0][FIX] account_statement_import: abs lines don't need partner_bank_id field

### DIFF
--- a/account_statement_import/__manifest__.py
+++ b/account_statement_import/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Import Statement Files",
     "category": "Accounting",
-    "version": "14.0.1.2.3",
+    "version": "14.0.2.0.0",
     "license": "LGPL-3",
     "depends": ["account"],
     "author": "Odoo SA, Akretion, Odoo Community Association (OCA)",

--- a/account_statement_import/migrations/14.0.1.0.0/pre-migration.py
+++ b/account_statement_import/migrations/14.0.1.0.0/pre-migration.py
@@ -1,0 +1,23 @@
+# Copyright 2022 ForgeFlow S.L.  <https://www.forgeflow.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+_model_renames = [
+    (
+        "account.bank.statement.import",
+        "account.statement.import",
+    ),
+]
+
+_table_renames = [
+    (
+        "account_bank_statement_import",
+        "account_statement_import",
+    ),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_models(env.cr, _model_renames)
+    openupgrade.rename_tables(env.cr, _table_renames)

--- a/account_statement_import/migrations/14.0.2.0.0/pre-migration.py
+++ b/account_statement_import/migrations/14.0.2.0.0/pre-migration.py
@@ -1,0 +1,26 @@
+# Copyright 2022 ForgeFlow S.L.  <https://www.forgeflow.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if openupgrade.column_exists(
+        env.cr, "account_bank_statement_line", "partner_bank_id"
+    ):
+        # during v14, a partner_bank_id field was added to statement lines,
+        # but later we realized it is not needed.
+        # As we remove the explicit partner_bank_id in statement line, we need to transfer the
+        # values to the move for getting them through delegated inheritance
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE account_move am
+            SET partner_bank_id = absl.partner_bank_id
+            FROM account_bank_statement_line absl
+            WHERE am.statement_line_id = absl.id
+                AND am.partner_bank_id IS NULL AND absl.partner_bank_id IS NOT NULL""",
+        )
+        openupgrade.lift_constraints(
+            env.cr, "account_bank_statement_line", "partner_bank_id"
+        )

--- a/account_statement_import/models/account_bank_statement_line.py
+++ b/account_statement_import/models/account_bank_statement_line.py
@@ -12,10 +12,6 @@ class AccountBankStatementLine(models.Model):
     # Ensure transactions can be imported only once
     # (if the import format provides unique transaction ids)
     unique_import_id = fields.Char(string="Import ID", readonly=True, copy=False)
-    # v13 field: bank_partner_id
-    # This field was removed in v14, but it is still used in the code, cf the
-    # method reconcile() !!! So I restore the field here
-    partner_bank_id = fields.Many2one("res.partner.bank", string="Partner Bank Account")
 
     _sql_constraints = [
         (


### PR DESCRIPTION
Let them use the one from account moves.

Followup of https://github.com/OCA/OpenUpgrade/pull/3150.

NOTE: When merging this PR, use ocabot `major`