### PR TITLE
[14.0][FIX] account_statement_import_online: use unittest.mock and don't import tests at install

### DIFF
--- a/account_statement_import_online/__init__.py
+++ b/account_statement_import_online/__init__.py
@@ -2,4 +2,3 @@
 
 from . import models
 from . import wizards
-from .tests import online_bank_statement_provider_dummy

--- a/account_statement_import_online/__manifest__.py
+++ b/account_statement_import_online/__manifest__.py
@@ -11,6 +11,7 @@
     "license": "AGPL-3",
     "category": "Accounting",
     "summary": "Online bank statements update",
+    "external_dependencies": {"python": ["odoo_test_helper"]},
     "depends": [
         "account",
         "account_statement_import",

--- a/account_statement_import_online/tests/test_account_journal.py
+++ b/account_statement_import_online/tests/test_account_journal.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Therp BV (https://therp.nl).
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from mock import patch
+from unittest.mock import patch
 
 from odoo.tests import common
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # generated from manifests external_dependencies
+odoo_test_helper
 ofxparse
 xlrd


### PR DESCRIPTION
Installing this module failed because `mock` couldn't be found. Indeed there was a migration problem.

However, I was not testing the module; just installing. At install, tests shouldn't be imported.

Fixing both problems here.

@moduon MT-295