### PR TITLE
[12.0][FIX] *_ponto: solve exception on empty name

### DIFF
--- a/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
+++ b/account_bank_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
@@ -212,7 +212,7 @@ class OnlineBankStatementProviderPonto(models.Model):
                 'sequence': sequence,
                 'date': date,
                 'ref': re.sub(' +', ' ', ref) or '/',
-                'name': attributes.get('remittanceInformation', ref),
+                'name': attributes.get('remittanceInformation') or ref,
                 'unique_import_id': transaction['id'],
                 'amount': attributes['amount'],
             }


### PR DESCRIPTION
The name for a transaction imported from Ponto is taken from the remittanceInformation, failing that,
the reference should be used. However in case the transaction attributes do contain the
remittanceInformation key, but the value is False or empty, the failover to the reference fails.