### PR TITLE
[FIX] account_bank_statement_import_paypal don't declare standard python

### DIFF
--- a/account_bank_statement_import_paypal/__manifest__.py
+++ b/account_bank_statement_import_paypal/__manifest__.py
@@ -21,11 +21,6 @@
         'multi_step_wizard',
         'web_widget_dropdown_dynamic',
     ],
-    'external_dependencies': {
-        'python': [
-            'csv',
-        ]
-    },
     'data': [
         'security/ir.model.access.csv',
         'data/maps.xml',


### PR DESCRIPTION
this fixes runboat builds, as there's no package called `csv` to install, and won't hurt anywhere else because `csv` is part of python's standard lib