### PR TITLE
[WIP][14.0][ADD] account_statement_import_online_fints

### DIFF
--- a/account_statement_import_online_fints/__init__.py
+++ b/account_statement_import_online_fints/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/account_statement_import_online_fints/__manifest__.py
+++ b/account_statement_import_online_fints/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Karolin Schlegel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Online Bank Statements: FinTS",
+    "version": "14.0.0.0.0",
+    "category": "Account",
+    "author": "Karolin Schlegel, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "installable": True,
+    "external dependencies": {"python": ["fints"]},
+    "depends": ["account_statement_import_online"],
+    "data": ["view/online_bank_statement_provider.xml"],
+}

--- a/account_statement_import_online_fints/__manifest__.py
+++ b/account_statement_import_online_fints/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Online Bank Statements: FinTS",
-    "version": "14.0.0.0.0",
+    "version": "14.0.1.0.0",
     "category": "Account",
     "author": "Karolin Schlegel, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/account_statement_import_online_fints/i18n/account_statement_import_online_fints.pot
+++ b/account_statement_import_online_fints/i18n/account_statement_import_online_fints.pot
@@ -1,0 +1,67 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_statement_import_online_fints
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-05-25 07:59+0000\n"
+"PO-Revision-Date: 2022-05-25 07:59+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_statement_import_online_fints
+#: model_terms:ir.ui.view,arch_db:account_statement_import_online_fints.online_bank_statement_provider_form
+msgid "Bank Code"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: model:ir.model.fields,field_description:account_statement_import_online_fints.field_online_bank_statement_provider__blz
+msgid "Blz"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: model:ir.model.fields,field_description:account_statement_import_online_fints.field_online_bank_statement_provider__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: model_terms:ir.ui.view,arch_db:account_statement_import_online_fints.online_bank_statement_provider_form
+msgid "FinTS API Endpoint"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: code:addons/account_statement_import_online_fints/models/online_bank_statement_provider_fints.py:0
+#, python-format
+msgid "FinTs : wrong configuration, unknown account %s"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: model:ir.model.fields,field_description:account_statement_import_online_fints.field_online_bank_statement_provider__id
+msgid "ID"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: model:ir.model.fields,field_description:account_statement_import_online_fints.field_online_bank_statement_provider____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: model:ir.model,name:account_statement_import_online_fints.model_online_bank_statement_provider
+msgid "Online Bank Statement Provider"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: model_terms:ir.ui.view,arch_db:account_statement_import_online_fints.online_bank_statement_provider_form
+msgid "Password"
+msgstr ""
+
+#. module: account_statement_import_online_fints
+#: model_terms:ir.ui.view,arch_db:account_statement_import_online_fints.online_bank_statement_provider_form
+msgid "User Name"
+msgstr ""

--- a/account_statement_import_online_fints/i18n/de.po
+++ b/account_statement_import_online_fints/i18n/de.po
@@ -1,0 +1,62 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_statement_import_online_fints
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-05-25 07:59+0000\n"
+"PO-Revision-Date: 2022-05-25 07:59+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_statement_import_online_fints
+#: model_terms:ir.ui.view,arch_db:account_statement_import_online_fints.online_bank_statement_provider_form
+msgid "Bank Code"
+msgstr "Bankleitzahl"
+
+#. module: account_statement_import_online_fints
+#: model:ir.model.fields,field_description:account_statement_import_online_fints.field_online_bank_statement_provider__display_name
+msgid "Display Name"
+msgstr "Anzeigename"
+
+#. module: account_statement_import_online_fints
+#: model_terms:ir.ui.view,arch_db:account_statement_import_online_fints.online_bank_statement_provider_form
+msgid "FinTS API Endpoint"
+msgstr "FinTS-API-Endpunkt"
+
+#. module: account_statement_import_online_fints
+#: code:addons/account_statement_import_online_fints/models/online_bank_statement_provider_fints.py:0
+#, python-format
+msgid "FinTs : wrong configuration, unknown account %s"
+msgstr "FinTs : falsche Konfiguration, unbekanntes Konto %s"
+
+#. module: account_statement_import_online_fints
+#: model:ir.model.fields,field_description:account_statement_import_online_fints.field_online_bank_statement_provider__id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_statement_import_online_fints
+#: model:ir.model.fields,field_description:account_statement_import_online_fints.field_online_bank_statement_provider____last_update
+msgid "Last Modified on"
+msgstr "Zuletzt geändert am"
+
+#. module: account_statement_import_online_fints
+#: model:ir.model,name:account_statement_import_online_fints.model_online_bank_statement_provider
+msgid "Online Bank Statement Provider"
+msgstr "Anbieter von Online-Kontoauszügen"
+
+#. module: account_statement_import_online_fints
+#: model_terms:ir.ui.view,arch_db:account_statement_import_online_fints.online_bank_statement_provider_form
+msgid "Password"
+msgstr "Passwort"
+
+#. module: account_statement_import_online_fints
+#: model_terms:ir.ui.view,arch_db:account_statement_import_online_fints.online_bank_statement_provider_form
+msgid "User Name"
+msgstr "Nutzername"

--- a/account_statement_import_online_fints/models/__init__.py
+++ b/account_statement_import_online_fints/models/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import online_bank_statement_provider_fints

--- a/account_statement_import_online_fints/models/online_bank_statement_provider_fints.py
+++ b/account_statement_import_online_fints/models/online_bank_statement_provider_fints.py
@@ -21,8 +21,8 @@ class OnlineBankStatementProviderFinTS(models.Model):
             self.blz,
             self.username,
             self.password,
-            self.api_base,  # ENDPOINT
-            # product_id='Your product ID'
+            self.api_base,
+            product_id='63A162FC4F225D1FA082CE36C'
         )
         return fints_connection
 

--- a/account_statement_import_online_fints/models/online_bank_statement_provider_fints.py
+++ b/account_statement_import_online_fints/models/online_bank_statement_provider_fints.py
@@ -1,0 +1,108 @@
+# Copyright 2022 Karolin Schlegel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import datetime
+import re
+
+from fints.client import FinTS3PinTanClient
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class OnlineBankStatementProviderFinTS(models.Model):
+    _inherit = "online.bank.statement.provider"
+
+    blz = fields.Char()
+
+
+    def _init_connection(self):
+        fints_connection = FinTS3PinTanClient(
+            self.blz,
+            self.username,
+            self.password,
+            self.api_base,  # ENDPOINT
+            # product_id='Your product ID'
+        )
+        return fints_connection
+
+    @api.model
+    def _get_available_services(self):
+        return super()._get_available_services() + [
+            ("fints", "FinTS"),
+        ]
+
+    def _obtain_statement_data(self, date_since, date_until):
+        self.ensure_one()
+        if self.service != "fints":
+            return super()._obtain_statement_data(date_since, date_until)
+        return self._fints_obtain_statement_data(date_since, date_until)
+
+    #########
+    # fints #
+    #########
+
+    def _fints_get_account_ids(self, fints_connection):
+        accounts = fints_connection.get_sepa_accounts()
+        return accounts
+
+    def _fints_obtain_statement_data(self, date_since, date_until):
+        """Translate information from FinTS to Odoo bank statement lines."""
+        self.ensure_one()
+        fints_connection = self._init_connection()
+        account_ids = self._fints_get_account_ids(fints_connection)
+        journal = self.journal_id
+        iban = self.account_number
+        account_id = None
+        for account in account_ids:
+            if iban == account.iban:
+                 account_id = account
+        if not account_id:
+            raise UserError(
+                _("FinTs : wrong configuration, unknown account %s")
+                % journal.bank_account_id.acc_number
+            )
+        # FinTS can't consider future values for date_until. Therefore, we substract a second from date_until to avoid errors.
+        transaction_lines = fints_connection.get_transactions(account_id, date_since, date_until-datetime.timedelta(seconds=1))
+        new_transactions = []
+        sequence = 0
+        for transaction in transaction_lines:
+            sequence += 1
+            vals_line = self._fints_get_transaction_vals(transaction, sequence)
+            new_transactions.append(vals_line)
+        if new_transactions:
+            return new_transactions, {}
+        return
+
+
+
+    def _fints_get_transaction_vals(self, transaction, sequence):
+        """Translate information from FinTS to statement line vals."""
+        attributes = transaction.data
+        ref_list = [
+            attributes[x]
+            for x in {"purpose", "applicant_name", "applicant_iban"}
+            if attributes[x]
+        ]
+        ref = " ".join(ref_list)
+        date = attributes['date']
+        vals_line = {
+            "sequence": sequence,
+            "date": date,
+            "ref": re.sub(" +", " ", ref) or "/",
+            "payment_ref": attributes['purpose'],
+            "amount": attributes['amount'].amount,
+            "unique_import_id": "{0},{1},{2},{3},{4}".format(
+                date,
+                attributes['amount'].amount,
+                attributes['applicant_name'],
+                attributes['posting_text'],
+                attributes['purpose']
+            ),
+            "online_raw_data": attributes,
+        }
+        if attributes['applicant_iban']:
+            vals_line["account_number"] = attributes['applicant_iban']
+        if attributes['applicant_name']:
+            vals_line["partner_name"] = attributes['applicant_name']
+        return vals_line

--- a/account_statement_import_online_fints/readme/CONFIGURE.rst
+++ b/account_statement_import_online_fints/readme/CONFIGURE.rst
@@ -1,0 +1,24 @@
+To configure online bank statements provider:
+
+#. Go to *Invoicing > Configuration > Bank Accounts*
+#. Open bank account to configure and edit it
+#. Set *Bank Feeds* to *Online*
+#. Select *FinTS* as online bank statements provider in
+   *Online Bank Statements (OCA)* section
+#. Save the bank account
+#. Click on provider and configure provider-specific settings.
+
+or, alternatively:
+
+#. Go to *Invoicing > Overview*
+#. Open settings of the corresponding journal account
+#. Switch to *Bank Account* tab
+#. Set *Bank Feeds* to *Online*
+#. Select *FinTS* as online bank statements provider in
+   *Online Bank Statements (OCA)* section
+#. Save the bank account
+#. Click on provider and configure provider-specific settings.
+
+
+Check also ``account_bank_statement_import_online`` configuration instructions
+for more information.

--- a/account_statement_import_online_fints/readme/CONTRIBUTORS.rst
+++ b/account_statement_import_online_fints/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Karolin Schlegel

--- a/account_statement_import_online_fints/readme/DESCRIPTION.rst
+++ b/account_statement_import_online_fints/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module provides online account statements using FinTS.

--- a/account_statement_import_online_fints/readme/USAGE.rst
+++ b/account_statement_import_online_fints/readme/USAGE.rst
@@ -1,0 +1,10 @@
+To pull historical bank statements:
+
+#. Go to *Invoicing > Configuration > Bank Accounts*
+#. Select specific bank accounts
+#. Launch *Actions > Online Bank Statements Pull Wizard*
+#. Configure date interval and click *Pull*
+
+If historical data is not needed, then just simply wait for the scheduled
+activity "Pull Online Bank Statements" to be executed for getting new
+transactions.

--- a/account_statement_import_online_fints/view/online_bank_statement_provider.xml
+++ b/account_statement_import_online_fints/view/online_bank_statement_provider.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="online_bank_statement_provider_form">
+        <field name="name">online.bank.statement.provider.form</field>
+        <field name="model">online.bank.statement.provider</field>
+        <field
+            name="inherit_id"
+            ref="account_statement_import_online.online_bank_statement_provider_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='main']" position="inside">
+                <group name="fints" attrs="{'invisible':[('service','!=','fints')]}">
+                    <field name="blz" string="Bank Code" />
+                    <field name="username" string="User Name"/>
+                    <field name="password" string="Password" />
+                    <field name="api_base" string="FinTS API Endpoint"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 odoo_test_helper
 ofxparse
 xlrd
+fints


### PR DESCRIPTION
Hello,
I have created an addon to the module `account_statement_import_online` for the use of FinTS. FinTS is a bank interface commonly used in Germany and supported by nearly every German bank.

Currently, bank statements can be imported as long as no TAN entry is required.
A product ID, which is required for establishing the connection so that the process is not blocked in the event of multiple queries, has already been requested and will be added as soon as it is available.

Other functions that are planned are:

- Handling of TAN queries
- Making bank transfers