### PR TITLE
[FIX] duplicate unique_import_id upon multiple entries in one transaction

### DIFF
--- a/account_bank_statement_import_camt/models/parser.py
+++ b/account_bank_statement_import_camt/models/parser.py
@@ -173,6 +173,8 @@ class CamtParser(models.AbstractModel):
         transaction_base = transaction
         for i, dnode in enumerate(detail_nodes):
             transaction = copy(transaction_base)
+            if transaction.get('unique_import_id') and i > 0:
+                transaction['unique_import_id'] += '-%d' % (i,)
             self.parse_transaction_details(dnode, transaction)
             self.default_transaction_data(node, transaction)
             transaction.data = etree.tostring(dnode)


### PR DESCRIPTION
When dealing with a statement that has multiple entries for the same transaction, the unique_import_id is set the same for all these entries, hence importing such a statement produces an error of _bank account transaction can be imported only once_. This solves that issue.

BEFORE


```
NL20ABNA1234567890-0123456789.2022-06-280001
NL20ABNA1234567890-0123456789.2022-06-280002
NL20ABNA1234567890-0123456789.2022-06-280003
NL20ABNA1234567890-0123456789.2022-06-280004
NL20ABNA1234567890-0123456789.2022-06-280005
NL20ABNA1234567890-0123456789.2022-06-280006
NL20ABNA1234567890-0123456789.2022-06-280007
NL20ABNA1234567890-0123456789.2022-06-280008
NL20ABNA1234567890-0123456789.2022-06-280009
NL20ABNA1234567890-0123456789.2022-06-280010
NL20ABNA1234567890-0123456789.2022-06-280011
NL20ABNA1234567890-0123456789.2022-06-280011  # fails
NL20ABNA1234567890-0123456789.2022-06-280011
NL20ABNA1234567890-0123456789.2022-06-280011
```

AFTER:

```
NL20ABNA1234567890-0123456789.2022-06-280001
NL20ABNA1234567890-0123456789.2022-06-280002
NL20ABNA1234567890-0123456789.2022-06-280003
NL20ABNA1234567890-0123456789.2022-06-280004
NL20ABNA1234567890-0123456789.2022-06-280005
NL20ABNA1234567890-0123456789.2022-06-280006
NL20ABNA1234567890-0123456789.2022-06-280007
NL20ABNA1234567890-0123456789.2022-06-280008
NL20ABNA1234567890-0123456789.2022-06-280009
NL20ABNA1234567890-0123456789.2022-06-280010
NL20ABNA1234567890-0123456789.2022-06-280011
NL20ABNA1234567890-0123456789.2022-06-280011-1
NL20ABNA1234567890-0123456789.2022-06-280011-2
NL20ABNA1234567890-0123456789.2022-06-280011-3
```