### PR TITLE
[14.0][FIX] account_statement_import: Add statement_line_ids in context of import_file_button() function

### DIFF
--- a/account_statement_import/wizard/account_statement_import.py
+++ b/account_statement_import/wizard/account_statement_import.py
@@ -6,6 +6,7 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools.safe_eval import safe_eval
 
 from odoo.addons.base.models.res_bank import sanitize_account_number
 
@@ -51,6 +52,11 @@ class AccountStatementImport(models.TransientModel):
         action = self.env["ir.actions.actions"]._for_xml_id(
             "account.action_bank_statement_tree"
         )
+        action["context"] = safe_eval(action.get("context", "{}"))
+        lines = self.env["account.bank.statement.line"].search(
+            [("statement_id", "in", result["statement_ids"])]
+        )
+        action["context"].update({"statement_line_ids": lines.ids})
         if len(result["statement_ids"]) == 1:
             action.update(
                 {


### PR DESCRIPTION
Add `statement_line_ids` in context of `import_file_button()` function

Removed in https://github.com/OCA/bank-statement-import/commit/8987b4c9937136f5db587d2bc442b92efdbddb29

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa