### PR TITLE
[14.0][FIX] *_import_online: Just use cron scheduling

### DIFF
--- a/account_statement_import_online/views/online_bank_statement_provider.xml
+++ b/account_statement_import_online/views/online_bank_statement_provider.xml
@@ -35,8 +35,7 @@
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="service" />
                 <field name="currency_id" />
-                <field name="update_schedule" />
-                <field name="next_run" />
+                <field name="last_successful_run" />
             </tree>
         </field>
     </record>
@@ -69,12 +68,7 @@
                             <field name="active" invisible="1" />
                         </group>
                         <group name="pull" string="Scheduled Pull">
-                            <label for="interval_number" />
-                            <div class="o_row" id="interval_number">
-                                <field name="interval_number" class="ml8" />
-                                <field name="interval_type" />
-                            </div>
-                            <field name="next_run" />
+                            <field name="last_successful_run" />
                         </group>
                         <group name="configuration" string="Configuration">
                             <field name="statement_creation_mode" />


### PR DESCRIPTION
Rely on cron scheduling. This solves the problem that when the scheduled pull doest not always run, due to downtime or other caused, the next_run, is more and more behind the current time.