### PR TITLE
[15.0][FIX] Update copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,9 +1,14 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.7.0
+_commit: v1.11.0
 _src_path: git+https://github.com/oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
+github_check_license: true
+github_enable_codecov: true
+github_enable_makepot: true
+github_enable_stale_action: true
+github_enforce_dev_status_compatibility: true
 include_wkhtmltopdf: false
 odoo_version: 15.0
 org_name: Odoo Community Association (OCA)

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ build/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,19 +119,15 @@ repos:
       - id: flake8
         name: flake8
         additional_dependencies: ["flake8-bugbear==21.9.2"]
-  - repo: https://github.com/PyCQA/pylint
-    rev: v2.11.1
+  - repo: https://github.com/OCA/pylint-odoo
+    rev: 7.0.2
     hooks:
-      - id: pylint
+      - id: pylint_odoo
         name: pylint with optional checks
         args:
           - --rcfile=.pylintrc
           - --exit-zero
         verbose: true
-        additional_dependencies: &pylint_deps
-          - pylint-odoo==5.0.5
-      - id: pylint
-        name: pylint with mandatory checks
+      - id: pylint_odoo
         args:
           - --rcfile=.pylintrc-mandatory
-        additional_dependencies: *pylint_deps


### PR DESCRIPTION
For avoiding library versions problem with Python 3.11

@Tecnativa