### PR TITLE
[ADD] account_bank_statement_import_txt_xlsx: existing statemnet

### DIFF
--- a/account_statement_import_txt_xlsx/models/__init__.py
+++ b/account_statement_import_txt_xlsx/models/__init__.py
@@ -3,4 +3,5 @@
 from . import account_statement_import_sheet_mapping
 from . import account_statement_import_sheet_parser
 from . import account_statement_import
+from . import account_bank_statement
 from . import account_journal

--- a/account_statement_import_txt_xlsx/models/account_bank_statement.py
+++ b/account_statement_import_txt_xlsx/models/account_bank_statement.py
@@ -1,0 +1,23 @@
+from odoo import api, models
+
+
+class AccountBankStatement(models.Model):
+
+    _inherit = "account.bank.statement"
+
+    @api.model_create_multi
+    def create(self, vals):
+        """When we do import of bank statement lines will always create a new
+        statement, If we want to re use an existing one then we need to be able
+        to make the switch in this method in order that all new lines go to
+        the statement we want to reuse"""
+        res = super(AccountBankStatement, self).create(vals)
+
+        existing_st = self.env.context.get("reuse_import_st_id")
+        if existing_st:
+            existing_st = self.browse(existing_st)
+            existing_st.line_ids |= res.line_ids
+            res.unlink()
+            return existing_st
+
+        return res

--- a/account_statement_import_txt_xlsx/models/account_statement_import.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import.py
@@ -24,6 +24,12 @@ class AccountStatementImport(models.TransientModel):
         default=_get_default_mapping_id,
     )
 
+    bank_statement_id = fields.Many2one(
+        "account.bank.statement",
+        string="Statement",
+        domain=lambda self: [("journal_id", "=", self.env.context.get("journal_id"))],
+    )
+
     def _parse_file(self, data_file):
         self.ensure_one()
         if self.sheet_mapping_id:
@@ -47,3 +53,9 @@ class AccountStatementImport(models.TransientModel):
                 amount = sum(statement.line_ids.mapped("amount"))
                 statement.balance_end_real = statement.balance_start + amount
         return res
+
+    def import_file_button(self):
+        return super(
+            AccountStatementImport,
+            self.with_context(reuse_import_st_id=self.bank_statement_id.id),
+        ).import_file_button()

--- a/account_statement_import_txt_xlsx/tests/test_account_statement_import_txt_xlsx.py
+++ b/account_statement_import_txt_xlsx/tests/test_account_statement_import_txt_xlsx.py
@@ -450,3 +450,42 @@ class TestAccountBankStatementImportTxtXlsx(common.TransactionCase):
         self.assertEqual(statement.balance_start, 10.0)
         self.assertEqual(statement.balance_end_real, 1510.0)
         self.assertEqual(statement.balance_end, 1510.0)
+
+    def test_use_existing_bank_statement(self):
+        journal = self.AccountJournal.create(
+            {
+                "name": "Bank",
+                "type": "bank",
+                "code": "BANK",
+                "currency_id": self.currency_usd.id,
+            }
+        )
+        statement_map = self.sample_statement_map.copy(
+            {
+                "balance_column": "Balance",
+                "original_currency_column": None,
+                "original_amount_column": None,
+            }
+        )
+
+        statement = self.AccountBankStatement.create(
+            {"journal_id": journal.id, "name": "Existing Extract"}
+        )
+
+        data = self._data_file("fixtures/debit_credit.csv", "utf-8")
+        wizard = self.AccountStatementImport.with_context(journal_id=journal.id).create(
+            {
+                "statement_filename": "fixtures/debit_credit.csv",
+                "statement_file": data,
+                "sheet_mapping_id": statement_map.id,
+                "bank_statement_id": statement.id,
+            }
+        )
+        wizard.with_context(
+            account_bank_statement_import_txt_xlsx_test=True
+        ).import_file_button()
+        res_statement = self.AccountBankStatement.search(
+            [("journal_id", "=", journal.id)]
+        )
+        self.assertEqual(len(res_statement), 1)
+        self.assertEqual(statement, res_statement)

--- a/account_statement_import_txt_xlsx/views/account_statement_import.xml
+++ b/account_statement_import_txt_xlsx/views/account_statement_import.xml
@@ -18,6 +18,11 @@
                     TXT/CSV/XLSX mapping: <field name="sheet_mapping_id" nolabel="1" />
                 </li>
             </xpath>
+            <xpath expr="//ul[@id='statement_format']" position="inside">
+                <li>
+                    Import in statement: <field name="bank_statement_id" nolabel="1" />
+                </li>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Be able to import lines to and existing statement instead of create a new one everytime. This is usefull because if the user group the staments by month they are able to made the importation several times in the same month checking the balance as they have in the bank instead of have different statments on per each import