### PR TITLE
[ADD] account_statement_import_txt_xlsx: show mapping error

### DIFF
--- a/account_statement_import_txt_xlsx/models/account_statement_import.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import.py
@@ -3,7 +3,8 @@
 
 import logging
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -32,10 +33,11 @@ class AccountStatementImport(models.TransientModel):
                 return Parser.parse(
                     data_file, self.sheet_mapping_id, self.statement_filename
                 )
-            except BaseException:
+            except BaseException as exc:
                 if self.env.context.get("account_statement_import_txt_xlsx_test"):
                     raise
                 _logger.warning("Sheet parser error", exc_info=True)
+                raise UserError(_("Bad file/mapping: ") + str(exc)) from exc
         return super()._parse_file(data_file)
 
     def _create_bank_statements(self, stmts_vals, result):


### PR DESCRIPTION
If there is a problem parsing the file we are not showing the error to the user, instead a generic message telling something is wrong with the type of file is shown which is not helpful (see image bellow), and we only show the error if we are running unit tests.

![image](https://user-images.githubusercontent.com/7593953/202002457-b51a37f6-0e73-4849-b16b-6c5d8f4b178f.png)

In this case, we think is good to show the error to the user, at least part of it, that way they can check what is wrong with the sheet mapping and fix it.

* We are only showing the title of the error as a HINT, we think that is a good start to understand what needs to change in the sheet mapping. Example   ![image](https://user-images.githubusercontent.com/7593953/202003176-6fa20f2d-858d-408a-95b7-1adc23c06c6f.png)

* The complete traceback error is shown in the log if we needed for more detailed reviews from the technical teams. Example  ![image](https://user-images.githubusercontent.com/7593953/202003290-ac16d3d6-c393-4d34-bbfc-71ad2d29aa0e.png)
