### PR TITLE
[13.0][FIX] Fix parser that returns AddtlTxInf as statement line data

### DIFF
--- a/account_bank_statement_import_camt_oca/models/parser.py
+++ b/account_bank_statement_import_camt_oca/models/parser.py
@@ -55,7 +55,7 @@ class CamtParser(models.AbstractModel):
 
     def parse_transaction_details(self, ns, node, transaction):
         """Parse TxDtls node."""
-        # message
+        # name
         self.add_value_from_node(
             ns,
             node,
@@ -67,10 +67,6 @@ class CamtParser(models.AbstractModel):
             transaction,
             "name",
             join_str="\n",
-        )
-        # name
-        self.add_value_from_node(
-            ns, node, ["./ns:AddtlTxInf"], transaction, "AddtlTxInf", join_str="\n"
         )
         # eref
         self.add_value_from_node(


### PR DESCRIPTION
AddtlTxInf is treated later in _add_line_note method. Don't add it as key/value pair to the bank statement line creation