### PR TITLE
[IMP] account_statment_import: Add button for importing on top

### DIFF
--- a/account_statement_import/__manifest__.py
+++ b/account_statement_import/__manifest__.py
@@ -17,9 +17,11 @@
         "security/ir.model.access.csv",
         "wizard/account_statement_import_view.xml",
         "views/account_journal.xml",
+        "templates/assets.xml",
     ],
     "demo": [
         "demo/partner_bank.xml",
     ],
     "installable": True,
+    "qweb": ["static/src/xml/account_dashboard_kanban.xml"],
 }

--- a/account_statement_import/static/src/js/account_dashboard_kanban.js
+++ b/account_statement_import/static/src/js/account_dashboard_kanban.js
@@ -1,0 +1,21 @@
+odoo.define("account_statement_import.dashboard.kanban", function (require) {
+    "use strict";
+    var viewRegistry = require("web.view_registry");
+
+    var AccountDashboardView = viewRegistry.get("account_dashboard_kanban");
+    var AccountDashboardController = AccountDashboardView.prototype.config.Controller;
+    AccountDashboardController.include({
+        buttons_template: "AccountDashboardView.buttons",
+        // We are reusing the create button
+        _onButtonNew: function (ev) {
+            ev.stopPropagation();
+            return this.trigger_up("do_action", {
+                action: "account_statement_import.account_statement_import_action",
+            });
+        },
+    });
+    return {
+        AccountDashboardView: AccountDashboardView,
+        AccountDashboardController: AccountDashboardController,
+    };
+});

--- a/account_statement_import/static/src/xml/account_dashboard_kanban.xml
+++ b/account_statement_import/static/src/xml/account_dashboard_kanban.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<template>
+    <t t-name="AccountDashboardView.buttons">
+        <div>
+            <button
+                type="button"
+                t-attf-class="btn #{btnClass} o-kanban-button-new"
+                accesskey="c"
+            >
+                <t t-esc="_t('Import Statement (OCA)')" />
+            </button>
+        </div>
+    </t>
+</template>

--- a/account_statement_import/templates/assets.xml
+++ b/account_statement_import/templates/assets.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template id="assets_backend" name="account assets" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/account_statement_import/static/src/js/account_dashboard_kanban.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/account_statement_import/wizard/account_statement_import.py
+++ b/account_statement_import/wizard/account_statement_import.py
@@ -220,6 +220,15 @@ class AccountStatementImport(models.TransientModel):
                 ],
                 limit=1,
             )
+            journal_id = self.env.context.get("journal_id")
+            if journal_id and journal.id != journal_id:
+                raise UserError(
+                    _(
+                        "The journal found for the file is not consistent with the "
+                        "selected journal. You should use the proper journal or "
+                        "use the generic button on the top of the Accounting Dashboard"
+                    )
+                )
 
             if not journal:
                 bank_accounts = self.env["res.partner.bank"].search(

--- a/account_statement_import/wizard/account_statement_import_view.xml
+++ b/account_statement_import/wizard/account_statement_import_view.xml
@@ -39,4 +39,12 @@
             <field name="target">new</field>
         </record>
 
+
+        <record id="account_statement_import_menu" model="ir.ui.menu">
+            <field name="name">Import Statement</field>
+            <field name="parent_id" ref="account.menu_finance_entries_actions" />
+            <field name="action" ref="account_statement_import_action" />
+            <field name="sequence" eval="70" />
+        </record>
+
 </odoo>

--- a/account_statement_import/wizard/account_statement_import_view.xml
+++ b/account_statement_import/wizard/account_statement_import_view.xml
@@ -39,7 +39,6 @@
             <field name="target">new</field>
         </record>
 
-
         <record id="account_statement_import_menu" model="ir.ui.menu">
             <field name="name">Import Statement</field>
             <field name="parent_id" ref="account.menu_finance_entries_actions" />


### PR DESCRIPTION
This PR has two goals:

- [x] Adding a button on the top of the Journal Dashboard to import files
- [x] Block the import of statements from different journals if we use the one from the journal item

The main goal is to simplify the usage (and make it more consistent)

@pedrobaeza as talked on OCA/l10n-spain#2610