### PR TITLE
[FIX] account_statement_import

### DIFF
--- a/account_statement_import/static/src/js/account_dashboard_kanban.js
+++ b/account_statement_import/static/src/js/account_dashboard_kanban.js
@@ -3,19 +3,23 @@ odoo.define("account_statement_import.dashboard.kanban", function (require) {
     var viewRegistry = require("web.view_registry");
 
     var AccountDashboardView = viewRegistry.get("account_dashboard_kanban");
-    var AccountDashboardController = AccountDashboardView.prototype.config.Controller;
-    AccountDashboardController.include({
-        buttons_template: "AccountDashboardView.buttons",
-        // We are reusing the create button
-        _onButtonNew: function (ev) {
-            ev.stopPropagation();
-            return this.trigger_up("do_action", {
-                action: "account_statement_import.account_statement_import_action",
-            });
-        },
-    });
-    return {
-        AccountDashboardView: AccountDashboardView,
-        AccountDashboardController: AccountDashboardController,
-    };
+    // Value can be undefined on some test scenarios. Avoid an error by checking if it is defined
+    if (AccountDashboardView !== undefined) {
+        var AccountDashboardController =
+            AccountDashboardView.prototype.config.Controller;
+        AccountDashboardController.include({
+            buttons_template: "AccountDashboardView.buttons",
+            // We are reusing the create button
+            _onButtonNew: function (ev) {
+                ev.stopPropagation();
+                return this.trigger_up("do_action", {
+                    action: "account_statement_import.account_statement_import_action",
+                });
+            },
+        });
+        return {
+            AccountDashboardView: AccountDashboardView,
+            AccountDashboardController: AccountDashboardController,
+        };
+    }
 });

--- a/account_statement_import/views/account_journal.xml
+++ b/account_statement_import/views/account_journal.xml
@@ -11,6 +11,13 @@
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.account_journal_dashboard_kanban_view" />
         <field name="arch" type="xml">
+            <!--
+                We need to add the create tag in order to show buttons.
+                However, we will change them using the JS definition.
+            -->
+            <kanban position="attributes">
+                <attribute name="create">1</attribute>
+            </kanban>
             <xpath expr='//span[@name="button_import_placeholder"]' position='inside'>
                 <span>or <a
                         type="object"


### PR DESCRIPTION
This PR fixes two cases:

- It was leading to some JS test errors because the registry has not been correctly loaded. It might happen if you had this module installed and you tested `web_disable_export_group`
- The button was not showed because the create attribute must be set to 1. It will be modified later by the JS (probably an error from my local installation :cry: )

@pedrobaeza 