### PR TITLE
[15.0]account_statement_import - set correct company_id on ir_attachment

### DIFF
--- a/account_statement_import/wizard/account_statement_import.py
+++ b/account_statement_import/wizard/account_statement_import.py
@@ -74,10 +74,13 @@ class AccountStatementImport(models.TransientModel):
         return action
 
     def _prepare_create_attachment(self, result):
+        # Attach to first bank statement
+        res_id = result["statement_ids"][0]
+        st = self.env["account.bank.statement"].browse(res_id)
         vals = {
             "name": self.statement_filename,
-            # Attach to first bank statement
-            "res_id": result["statement_ids"][0],
+            "res_id": res_id,
+            "company_id": st.company_id.id,
             "res_model": "account.bank.statement",
             "datas": self.statement_file,
         }


### PR DESCRIPTION
Small fix to set correct company_id on bank statement attachments.

At this point in time, setting the incorrect company_id (the first from the 'allowed_company_ids' is set) has no operational effect on a standard Odoo setup since there are no record rules on ir.attachments, hence a wrong company_id has no operational impact.
