### PR TITLE
[12.0][IMP] account_bank_statement_import_txt_xlsx :extract IBAN from Description column during import, using the boolean field check from mapping

### DIFF
--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_mapping.py
@@ -147,6 +147,7 @@ class AccountBankStatementImportSheetMapping(models.Model):
         string='Bank Account column',
         help='Partner\'s bank account',
     )
+    get_iban_from_description = fields.Boolean(string="Get IBAN from Description")
 
     @api.onchange('float_thousands_sep')
     def onchange_thousands_separator(self):
@@ -161,6 +162,11 @@ class AccountBankStatementImportSheetMapping(models.Model):
             self.float_thousands_sep = 'comma'
         elif 'comma' == self.float_thousands_sep == self.float_decimal_sep:
             self.float_thousands_sep = 'dot'
+
+    @api.onchange("get_iban_from_description")
+    def onchange_get_iban_from_description(self):
+        if self.get_iban_from_description:
+            self.bank_account_column = ""
 
     @api.multi
     def _get_float_separators(self):

--- a/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
+++ b/account_bank_statement_import_txt_xlsx/models/account_bank_statement_import_sheet_parser.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from io import StringIO
 from os import path
 import itertools
+import re
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -195,6 +196,13 @@ class AccountBankStatementImportSheetParser(models.TransientModel):
                 if bank_name_column is not None else None
             bank_account = values[bank_account_column] \
                 if bank_account_column is not None else None
+
+            if mapping.get_iban_from_description:
+                iban_codes = re.findall(
+                    r"\b(DE(?:\s*[0-9]){20}|AT(?:\s*[0-9]){18})\b(?!\s*[0-9])",
+                    description,
+                )
+                bank_account = iban_codes[0] if iban_codes else bank_account
 
             if currency != currency_code:
                 continue

--- a/account_bank_statement_import_txt_xlsx/views/account_bank_statement_import_sheet_mapping.xml
+++ b/account_bank_statement_import_txt_xlsx/views/account_bank_statement_import_sheet_mapping.xml
@@ -53,12 +53,13 @@
                         <field name="original_amount_column"/>
                         <field name="debit_credit_column"/>
                         <field name="transaction_id_column"/>
-                        <field name="description_column"/>
+                        <field name="description_column" attrs="{'required': [('get_iban_from_description', '!=', False)]}" />
                         <field name="notes_column"/>
                         <field name="reference_column"/>
                         <field name="partner_name_column"/>
                         <field name="bank_name_column"/>
-                        <field name="bank_account_column"/>
+                        <field name="get_iban_from_description" />
+                        <field name="bank_account_column" attrs="{'invisible': [('get_iban_from_description', '!=', False)]}" />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
**Improvements**
- added a new boolean field `get_iban_from_description` in model `account.bank.statement.import.sheet.mapping`
-  if the boolean field is checked, we can extract IBAN from the Description column during the import of bank statements