### PR TITLE
[FIX] account_statement_import_online_paypal: empty statements create…

### DIFF
--- a/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
+++ b/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
@@ -206,8 +206,11 @@ class OnlineBankStatementProviderPayPal(models.Model):
             token, currency, date_since, date_until
         )
         if not transactions:
-            balance = self._paypal_get_balance(token, currency, date_since)
-            return [], {"balance_start": balance, "balance_end_real": balance}
+            if self.allow_empty_statements:
+                balance = self._paypal_get_balance(token, currency, date_since)
+                return [], {"balance_start": balance, "balance_end_real": balance}
+            else:
+                return None
 
         # Normalize transactions, sort by date, and get lines
         transactions = list(


### PR DESCRIPTION
…d regardless of configuration setting

Empty statements are created upon each download from PayPal regardless of the setting of the "Allow Empty Statements" field (allow_empty_statements) because this field is checked within an _if statement_ that can never be true. This fix checks allow_empty_statements and aborts the statement creation as appropriate.