### PR TITLE
[15.0][FIX] account_statement_import_online_paypal: force observance of allow_empty_statements field

### DIFF
--- a/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
+++ b/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
@@ -206,8 +206,11 @@ class OnlineBankStatementProviderPayPal(models.Model):
             token, currency, date_since, date_until
         )
         if not transactions:
-            balance = self._paypal_get_balance(token, currency, date_since)
-            return [], {"balance_start": balance, "balance_end_real": balance}
+            if self.allow_empty_statements:
+                balance = self._paypal_get_balance(token, currency, date_since)
+                return [], {"balance_start": balance, "balance_end_real": balance}
+            else:
+                return None
 
         # Normalize transactions, sort by date, and get lines
         transactions = list(


### PR DESCRIPTION
Empty statements should only be created if "Allow Empty Statements" is checked. This commit adds a check for the state of the allow_empty_statements field.