### PR TITLE
[FIX] account_statement_import: Ensure the load of the view

### DIFF
--- a/account_statement_import/static/src/js/account_dashboard_kanban.js
+++ b/account_statement_import/static/src/js/account_dashboard_kanban.js
@@ -1,7 +1,7 @@
 odoo.define("account_statement_import.dashboard.kanban", function (require) {
     "use strict";
     var viewRegistry = require("web.view_registry");
-
+    require("account.dashboard.kanban");
     var AccountDashboardView = viewRegistry.get("account_dashboard_kanban");
     // Value can be undefined on some test scenarios. Avoid an error by checking if it is defined
     if (AccountDashboardView !== undefined) {


### PR DESCRIPTION
In some cases, the loading was not working properly. By adding the require, the JS will wait until it is declared

Fixes #597