### PR TITLE
[14.0][IMP] account_statement_import_camt54 add the parameter to the view

### DIFF
--- a/account_statement_import_camt54/__manifest__.py
+++ b/account_statement_import_camt54/__manifest__.py
@@ -8,5 +8,6 @@
     "author": "camptocamp, " "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
+    "data": ["views/account_journal_view.xml"],
     "depends": ["account_statement_import_camt"],
 }

--- a/account_statement_import_camt54/models/account_journal.py
+++ b/account_statement_import_camt54/models/account_journal.py
@@ -10,5 +10,6 @@ class AccountBankStatementImport(models.Model):
 
     transfer_line = fields.Boolean(
         string="Add balance Line",
-        help="Generate balance line on total of bank statement import",
+        help="For camt54 files, generate balance line on total of bank statement "
+        "import",
     )

--- a/account_statement_import_camt54/models/account_statement_import.py
+++ b/account_statement_import_camt54/models/account_statement_import.py
@@ -20,8 +20,9 @@ class AccountStatementImport(models.TransientModel):
         statements = self.env["account.bank.statement"].browse(result["statement_ids"])
         for statement in statements:
             amount = sum(statement.line_ids.mapped("amount"))
-            if statement.journal_id.transfer_line:
-                if amount != 0:
+            journal = statement.journal_id
+            if journal.transfer_line:
+                if not journal.currency_id.is_zero(amount):
                     amount = -amount
                 statement.line_ids.create(
                     {

--- a/account_statement_import_camt54/views/account_journal_view.xml
+++ b/account_statement_import_camt54/views/account_journal_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="account_journal_statement_import_param_view" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='advanced_settings']/group" position="inside">
+                <group string="Statement">
+                    <field name="transfer_line" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The `transfer_line` parameter wasn't added to the view although it was defined in the model.