### PR TITLE
[16.0][FIX] account_statement_import_file: Rename file_import selection value to file_import_oca

### DIFF
--- a/account_statement_import_file/__manifest__.py
+++ b/account_statement_import_file/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Import Statement Files",
     "category": "Accounting",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "license": "LGPL-3",
     "depends": ["account_statement_import_base"],
     "author": "Odoo SA, Akretion, Odoo Community Association (OCA)",

--- a/account_statement_import_file/migrations/16.0.1.0.1/post-migration.py
+++ b/account_statement_import_file/migrations/16.0.1.0.1/post-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Landoo Sistemas de Informacion SL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_journal
+        SET bank_statements_source = 'file_import_oca'
+        WHERE bank_statements_source = 'file_import'
+        """,
+    )

--- a/account_statement_import_file/models/account_journal.py
+++ b/account_statement_import_file/models/account_journal.py
@@ -14,7 +14,7 @@ class AccountJournal(models.Model):
         res = super().default_get(fields_list)
         formats_list = self._get_bank_statements_available_import_formats()
         if formats_list:
-            res["bank_statements_source"] = "file_import"
+            res["bank_statements_source"] = "file_import_oca"
         return res
 
     def _get_bank_statements_available_import_formats(self):
@@ -28,7 +28,7 @@ class AccountJournal(models.Model):
             formats_list.sort()
             import_formats_str = ", ".join(formats_list)
             rslt.insert(
-                0, ("file_import", _("Import") + "(" + import_formats_str + ")")
+                0, ("file_import_oca", _("Import") + "(" + import_formats_str + ")")
             )
         return rslt
 

--- a/account_statement_import_file/views/account_journal.xml
+++ b/account_statement_import_file/views/account_journal.xml
@@ -15,7 +15,7 @@
                 expr='//a[@name="action_configure_bank_journal"]/..'
                 position='before'
             >
-                <t t-if="dashboard.bank_statements_source == 'file_import'">
+                <t t-if="dashboard.bank_statements_source == 'file_import_oca'">
                     <button
                         name="import_account_statement"
                         type="object"

--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -120,11 +120,11 @@ class AccountStatementImport(models.TransientModel):
         self._create_bank_statements(stmts_vals, result)
         # Now that the import worked out, set it as the bank_statements_source
         # of the journal
-        if journal.bank_statements_source != "file_import":
+        if journal.bank_statements_source != "file_import_oca":
             # Use sudo() because only 'account.group_account_manager'
             # has write access on 'account.journal', but 'account.group_account_user'
             # must be able to import bank statement files
-            journal.sudo().write({"bank_statements_source": "file_import"})
+            journal.sudo().write({"bank_statements_source": "file_import_oca"})
 
     def _parse_file(self, data_file):
         """Each module adding a file support must extends this method.


### PR DESCRIPTION
Both this module and enterprise's `account_bank_statement_import` module are adding the same key (`file_import`) to the list. This was not thowing errors until V15, but in V16 OWL is throwing a traceback because duplicated keys are not allowed.

This PR makes sure the key does not exist before adding it.

@ae-landoo @alexis-via @pedrobaeza