### PR TITLE
14.0_txt_xlsx_better_error_handling

### DIFF
--- a/account_statement_import_txt_xlsx/models/account_statement_import.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import fields, models
+from odoo import _, fields, models
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
@@ -35,13 +35,13 @@ class AccountStatementImport(models.TransientModel):
                 )
             except KeyError as e:
                 e_str = f"Could not find value for {e.args[0]!r}"
-                raise UserError(f"Failed to parse uploaded file!\n{e_str}")
+                raise UserError(_(f"Failed to parse uploaded file!\n{e_str}"))
             except ValueError as e:
                 e_str = f"Problem with a value in file\n{e}"
-                raise UserError(f"Failed to parse uploaded file!\n{e_str}")
-            except BaseException as e:
+                raise UserError(_(f"Failed to parse uploaded file!\n{e_str}"))
+            except BaseException:
                 if self.env.context.get("account_statement_import_txt_xlsx_test"):
-                    raise UserError("Failed to parse uploaded file!")
+                    raise UserError(_("Failed to parse uploaded file!"))
                 _logger.warning("Sheet parser error", exc_info=True)
         return super()._parse_file(data_file)
 

--- a/account_statement_import_txt_xlsx/models/account_statement_import.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import.py
@@ -37,12 +37,12 @@ class AccountStatementImport(models.TransientModel):
                 e_str = f"Could not find value for {e.args[0]!r}"
                 raise UserError(_(f"Failed to parse uploaded file!\n{e_str}"))
             except ValueError as e:
-                e_str = f"Problem with a value in file\n{e}"
+                e_str = f"Problem with the following value in file:\n{e}"
                 raise UserError(_(f"Failed to parse uploaded file!\n{e_str}"))
-            except BaseException:
-                if self.env.context.get("account_statement_import_txt_xlsx_test"):
-                    raise UserError(_("Failed to parse uploaded file!"))
-                _logger.warning("Sheet parser error", exc_info=True)
+            except BaseException as e:
+                _logger.error("Sheet parser error", exc_info=True)
+                raise UserError(_(f"Failed to parse uploaded file!\n{e}"))
+
         return super()._parse_file(data_file)
 
     def _create_bank_statements(self, stmts_vals, result):

--- a/account_statement_import_txt_xlsx/models/account_statement_import.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import.py
@@ -4,6 +4,7 @@
 import logging
 
 from odoo import fields, models
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
@@ -32,9 +33,15 @@ class AccountStatementImport(models.TransientModel):
                 return Parser.parse(
                     data_file, self.sheet_mapping_id, self.statement_filename
                 )
-            except BaseException:
+            except KeyError as e:
+                e_str = f"Could not find value for {e.args[0]!r}"
+                raise UserError(f"Failed to parse uploaded file!\n{e_str}")
+            except ValueError as e:
+                e_str = f"Problem with a value in file\n{e}"
+                raise UserError(f"Failed to parse uploaded file!\n{e_str}")
+            except BaseException as e:
                 if self.env.context.get("account_statement_import_txt_xlsx_test"):
-                    raise
+                    raise UserError("Failed to parse uploaded file!")
                 _logger.warning("Sheet parser error", exc_info=True)
         return super()._parse_file(data_file)
 

--- a/account_statement_import_txt_xlsx/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import_sheet_parser.py
@@ -424,11 +424,15 @@ class AccountStatementImportSheetParser(models.TransientModel):
 
     @api.model
     def _parse_decimal(self, value, mapping):
-        if isinstance(value, Decimal):
-            return value
-        elif isinstance(value, float):
-            return Decimal(value)
-        thousands, decimal = mapping._get_float_separators()
-        value = value.replace(thousands, "")
-        value = value.replace(decimal, ".")
-        return Decimal(value or 0)
+        try:
+            if isinstance(value, Decimal):
+                return value
+            elif isinstance(value, float):
+                return Decimal(value)
+            thousands, decimal = mapping._get_float_separators()
+            value = value.replace(thousands, "")
+            value = value.replace(decimal, ".")
+            value_decimal = Decimal(value or 0)
+        except Exception:
+            raise ValueError(_("Could not convert value %r to decimal") % (value,))
+        return value_decimal

--- a/account_statement_import_txt_xlsx/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import_sheet_parser.py
@@ -431,4 +431,4 @@ class AccountStatementImportSheetParser(models.TransientModel):
         thousands, decimal = mapping._get_float_separators()
         value = value.replace(thousands, "")
         value = value.replace(decimal, ".")
-        return Decimal(value)
+        return Decimal(value or 0)

--- a/account_statement_import_txt_xlsx/tests/fixtures/error_key_statement.csv
+++ b/account_statement_import_txt_xlsx/tests/fixtures/error_key_statement.csv
@@ -1,0 +1,3 @@
+"Date","Label","Currency","Amount","Balance","Partner Name","Bank Account"
+"12/15/2018","Your best supplier on 12/15/2018","USD","-33.50",,"John Doe","123456789"
+"12/15/2018","Your payment on 12/15/2018","EUR","1,525.00","1000.0","Azure Interior",

--- a/account_statement_import_txt_xlsx/tests/fixtures/error_value_statement.csv
+++ b/account_statement_import_txt_xlsx/tests/fixtures/error_value_statement.csv
@@ -1,0 +1,3 @@
+"Date","Label","Currency","Amount","Amount Currency","Partner Name","Bank Account"
+"12/15/2018","Your best supplier on 12/15/2018","USD","-33.50","0.0","John Doe","123456789"
+"12/15/2018/23","Your payment on 12/15/2018","EUR","1,525.00","1,000.00","Azure Interior",""


### PR DESCRIPTION
Currently any problem during parsing is reported as "File format not supported, did you install the Odoo module". Related issue: #603 

- Handle empty str* in amount as 0, prevents Decimal Conversion error
- Show more common file content problems: Key and Value error
- For all other errors, report as parsing error

*some banks provide CSVs with only debit or credit filled while leaving the other empty