### PR TITLE
[15.0][ADD] account_statement_import_txt_xlsx: Strip the currency symbol from numeric fields

### DIFF
--- a/account_statement_import_txt_xlsx/models/account_statement_import_sheet_mapping.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import_sheet_mapping.py
@@ -55,6 +55,11 @@ class AccountStatementImportSheetMapping(models.Model):
     )
     quotechar = fields.Char(string="Text qualifier", size=1, default='"')
     timestamp_format = fields.Char(required=True)
+    currency_ids = fields.Many2many(
+        comodel_name="res.currency",
+        string="Currencies",
+        help="Currencies used in the statement file",
+    )
     no_header = fields.Boolean(
         string="File does not contain header line",
         help="When this occurs please indicate the column number in the Columns section "

--- a/account_statement_import_txt_xlsx/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import_sheet_parser.py
@@ -429,6 +429,12 @@ class AccountStatementImportSheetParser(models.TransientModel):
             return value
         elif isinstance(value, float):
             return Decimal(value)
+
+        # strip currency symbol
+        for currency in mapping.currency_ids:
+            if currency.symbol and currency.symbol in value:
+                value = value.replace(currency.symbol, "")
+
         thousands, decimal = mapping._get_float_separators()
         value = value.replace(thousands, "")
         value = value.replace(decimal, ".")

--- a/account_statement_import_txt_xlsx/views/account_statement_import_sheet_mapping.xml
+++ b/account_statement_import_txt_xlsx/views/account_statement_import_sheet_mapping.xml
@@ -38,6 +38,7 @@
                         </group>
                         <group>
                             <field name="timestamp_format" />
+                            <field name="currency_ids" widget="many2many_tags" />
                         </group>
                         <group>
                             <field name="no_header" />


### PR DESCRIPTION
Some bank statements include the currency symbol in the numeric fields, this adds a field to list which currencies are being used in the statement and remove their symbol when parsing decimal lines.