### PR TITLE
[16.0][FIX] models/online_bank_statement_provider_ponto.py: prevent a…

### DIFF
--- a/account_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
+++ b/account_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
@@ -169,11 +169,9 @@ class OnlineBankStatementProvider(models.Model):
         # For each period, create or update statement lines
         for period, statement_lines in grouped_periods.items():
             (date_since, date_until) = period
-            statement = self._create_or_update_statement(
+            self._create_or_update_statement(
                 (statement_lines, {}), date_since, date_until
             )
-            for line in statement.line_ids.filtered(lambda l: not l.partner_id):
-                line.partner_id = line._retrieve_partner()
 
     def _ponto_get_transaction_vals(self, transaction):
         """Translate information from Ponto to statement line vals."""


### PR DESCRIPTION
…ttempt to modify of posted account.move

We have cases where the setattr on `line.partner_id` triggers modification on the associated `move_id` that is already in `"posted"` `state`. And this is refused. 

Please note that actually in our cases, even thou the `line._retrieve_partner()` value is still empty, the simple act of triggering the `line.partner_id` setattr is enough to get the exception.

We know this is not the proper fix, and we are not asking to integrate this PR, but wanted to have a discussion on this point. I'm not fully knowledgeable on the functional aspects that should be considered.

Many thanks for your feedback on this one and we'll be happy to contribute if you have any direction to suggest a better fix.