### PR TITLE
[15.0][FIX] account_statement_import_online_gocardless: Unique ID fallback

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -312,8 +312,11 @@ class OnlineBankStatementProvider(models.Model):
                     "payment_ref": tr.get(
                         "remittanceInformationUnstructured", partner_name
                     ),
-                    "unique_import_id": tr.get("entryReference", False)
-                    or tr.get("transactionId", False),
+                    "unique_import_id": (
+                        tr.get("entryReference")
+                        or tr.get("transactionId")
+                        or tr.get("internalTransactionId")
+                    ),
                     "amount": amount_currency,
                     "account_number": account_number,
                     "partner_name": partner_name,


### PR DESCRIPTION
Not all banks provide an entry reference or transaction ID, so we need to fallback to the Gocardless internal ID for getting the unique ID in such cases.

@Tecnativa TT46640