### PR TITLE
[15.0][FIX] account_statement_import_online_gocardless: Fallback to journal company

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -101,7 +101,9 @@ class OnlineBankStatementProvider(models.Model):
                 _("To continue configure bank account on journal %s")
                 % (self.journal_id.display_name)
             )
-        country = self.journal_id.bank_account_id.company_id.country_id
+        country = (
+            self.journal_id.bank_account_id.company_id or self.journal_id.company_id
+        ).country_id
         response = requests.get(
             f"{GOCARDLESS_ENDPOINT}/institutions/",
             params={"country": country.code},


### PR DESCRIPTION
If the bank account is shared across multiple companies (no assigned company_id), we can't launch the "Select Bank Account Identifier" wizard, so we fallback to the journal company for getting the country.

@Tecnativa TT43849