### PR TITLE
[15.0][FIX] account_statement_import_online_gocardless: Payment reference extraction

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -306,14 +306,18 @@ class OnlineBankStatementProvider(models.Model):
             ).get("iban", False)
             if account_number == own_acc_number:
                 account_number = False  # Discard own bank account number
+            if "remittanceInformationUnstructured" in tr:
+                payment_ref = tr["remittanceInformationUnstructured"]
+            elif "remittanceInformationUnstructuredArray" in tr:
+                payment_ref = " ".join(tr["remittanceInformationUnstructuredArray"])
+            else:
+                payment_ref = partner_name
             res.append(
                 {
                     "sequence": sequence,
                     "date": current_date,
                     "ref": partner_name or "/",
-                    "payment_ref": tr.get(
-                        "remittanceInformationUnstructured", partner_name
-                    ),
+                    "payment_ref": payment_ref,
                     "unique_import_id": (
                         tr.get("entryReference")
                         or tr.get("transactionId")


### PR DESCRIPTION
Since one week ago, banks like Sabadell is sending the information in the JSON list `remittanceInformationUnstructuredArray` instead of `remittanceInformationUnstructured`.

Thus, we need to parse both for finding the proper element. For the rest that are using the previous one, there's no change.

@Tecnativa TT47491