### PR TITLE
[16.0][FIX] account_statement_import_camt: fix label issue

### DIFF
--- a/account_statement_import_camt/test_files/golden-camt053-txdtls.pydata
+++ b/account_statement_import_camt/test_files/golden-camt053-txdtls.pydata
@@ -20,7 +20,7 @@
                                   'Account Servicer Reference (Refs/AcctSvcrRef): 123456CHCAFEBABE\n'
                                   'Postal Address (PstlAdr): Place Saint-François | 14 | 1003 | Lausanne | CH1',
                      'partner_name': 'Banque Cantonale Vaudoise',
-                     'payment_ref': '/',
+                     'payment_ref': 'CRÉDIT GROUPÉ BVR TRAITEMENT DU 22.03.2017 NUMÉRO CLIENT 01-70884-3 PAQUET ID: 123456CHCAFEBABE',
                      'ref': '302388292000011111111111111',
                      'transaction_type': 'PMNT-RCDT-VCOM'},
                     {'account_number': 'CH3333000000123456789',
@@ -39,6 +39,6 @@
                                   'Account Servicer Reference (Refs/AcctSvcrRef): 123456CHCAFEBABE\n'
                                   'Postal Address (PstlAdr): Place Saint-François | 14 | 1003 | Lausanne | CH2',
                      'partner_name': 'Banque Cantonale Vaudoise',
-                     'payment_ref': '/',
+                     'payment_ref': 'CRÉDIT GROUPÉ BVR TRAITEMENT DU 22.03.2017 NUMÉRO CLIENT 01-70884-3 PAQUET ID: 123456CHCAFEBABE',
                      'ref': '302388292000022222222222222',
                      'transaction_type': 'PMNT-RCDT-VCOM'}]}])


### PR DESCRIPTION
Add more info on payment reference instead of '/' when more info available