### PR TITLE
[14.0][IMP] Parse QR-Iban account for camt54 import

### DIFF
--- a/account_statement_import_camt54/models/parser.py
+++ b/account_statement_import_camt54/models/parser.py
@@ -98,3 +98,20 @@ class CamtParser(models.AbstractModel):
             "ref",
         )
         return True
+
+    def parse_statement(self, ns, node):
+        """In case of a camt54 file, the QR-IBAN to be used as the account_number
+        is found in another place than the IBAN."""
+        result = super().parse_statement(ns, node)
+        self.add_value_from_node(
+            ns,
+            node,
+            [
+                "./ns:Ntry[1]/ns:NtryRef",
+                "./ns:Acct/ns:Id/ns:IBAN",
+                "./ns:Acct/ns:Id/ns:Othr/ns:Id",
+            ],
+            result,
+            "account_number",
+        )
+        return result


### PR DESCRIPTION
To be able to import the camt054 statement into another journal, it needs to find the QR-IBAN instead of the IBAN.
This change enable to pick the QR-IBAN if existing, if not process the normal behavior.