### PR TITLE
[16.0][FIX] account_statement_import_online_gocardless: Increase timeout

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -14,7 +14,7 @@ from odoo.exceptions import UserError
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT as DF
 
 GOCARDLESS_ENDPOINT = "https://bankaccountdata.gocardless.com/api/v2"
-REQUESTS_TIMEOUT = 5
+REQUESTS_TIMEOUT = 60
 
 
 class OnlineBankStatementProvider(models.Model):


### PR DESCRIPTION
It turns out that the timeout is for receiving whole answer, so in real tests, the previous timeout was not enough for getting the answer when there are some transactions load (like a month).

Let's increase this timeout then to a reasonable amount.

@Tecnativa 