### PR TITLE
[15.0][FIX] account_statement_import_online: Avoid error in journal unlink test

### DIFF
--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -56,14 +56,17 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
             journal.online_bank_statement_provider_id.unlink()
 
     def test_cascade_unlink(self):
+        # Put high sequence for being the last one avoiding side effects
         journal = self.AccountJournal.create(
-            {"name": "Bank", "type": "bank", "code": "BANK"}
+            {"name": "Bank", "type": "bank", "code": "BANK", "sequence": 99999}
         )
         with common.Form(journal) as journal_form:
             journal_form.bank_statements_source = "online"
             journal_form.online_bank_statement_provider = "dummy"
         journal_form.save()
-
+        # Avoid problems with acquirers linked to this journal
+        journal.inbound_payment_method_line_ids.unlink()
+        journal.outbound_payment_method_line_ids.unlink()
         self.assertTrue(journal.online_bank_statement_provider_id)
         save_provider_id = journal.online_bank_statement_provider_id.id
         journal.unlink()


### PR DESCRIPTION
There's a chance that the recently created journal is selected for a payment acquirer thanks to this open compute:

https://github.com/OCA/OCB/blob/c5346c04a2e24fe236312988f173f166881b3567/addons/payment/models/payment_acquirer.py#L171-L180

and thus, when trying to unlink it, we get:

odoo.exceptions.UserError: You must first deactivate a payment acquirer before deleting its journal.

For avoiding this situation in integration tests, we do:

- Assign a higher sequence for being the last existing journal.
- Remove the payment method lines associated to the journal.

@Tecnativa 