### PR TITLE
[16.0][FIX] account_statement_import_online_gocardless: Unique ID prefer transactionId over entryReference.

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -364,8 +364,8 @@ class OnlineBankStatementProvider(models.Model):
                     "ref": partner_name or "/",
                     "payment_ref": payment_ref,
                     "unique_import_id": (
-                        tr.get("entryReference")
-                        or tr.get("transactionId")
+                        tr.get("transactionId")
+                        or tr.get("entryReference")
                         or tr.get("internalTransactionId")
                     ),
                     "amount": amount_currency,


### PR DESCRIPTION
At least one bank provides not unique entryReference. Suppose transactionID is unique.