### PR TITLE
[16][FIX] account_statement_import_online_qonto : fix import

### DIFF
--- a/account_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py
+++ b/account_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py
@@ -54,9 +54,7 @@ class OnlineBankStatementProviderQonto(models.Model):
     def _qonto_get_slug(self):
         self.ensure_one()
         url = QONTO_ENDPOINT + "/organizations/%7Bid%7D"
-        response = requests.get(
-            url, verify=False, headers=self._qonto_header(), timeout=10
-        )
+        response = requests.get(url, headers=self._qonto_header(), timeout=10)
         if response.status_code == 200:
             data = json.loads(response.text)
             res = {}
@@ -101,7 +99,6 @@ class OnlineBankStatementProviderQonto(models.Model):
     def _qonto_get_transactions(self, url, params):
         response = requests.get(
             url,
-            verify=False,
             params=params,
             headers=self._qonto_header(),
             timeout=10,

--- a/account_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py
+++ b/account_statement_import_online_qonto/models/online_bank_statement_provider_qonto.py
@@ -125,8 +125,9 @@ class OnlineBankStatementProviderQonto(models.Model):
         vals_line = {
             "sequence": sequence,
             "date": date,
-            "name": " - ".join([x for x in payment_ref_list if x]) or "/",
-            "ref": transaction["reference"],
+            "payment_ref": " - ".join([x for x in payment_ref_list if x]) or "/",
+            "narration": transaction["note"],
+            "transaction_type": transaction["operation_type"],
             "unique_import_id": transaction["transaction_id"],
             "amount": transaction["amount"] * side,
         }
@@ -153,7 +154,7 @@ class OnlineBankStatementProviderQonto(models.Model):
         if journal_currency.id != line_currency_id:
             vals_line.update(
                 {
-                    "currency_id": line_currency_id,
+                    "foreign_currency_id": line_currency_id,
                     "amount_currency": transaction["local_amount"] * side,
                 }
             )


### PR DESCRIPTION
I think there are some big issues on the v16 module.
Mainly, the `payment_ref` of the statement line is empty (although it is the main field that give us information about the transaction) and the number (field `name`) of the accounting entry is not the one of the journal, it is the label of the transaction!
Probably a confusion due to the fact that `account.bank.statement.line` inherits `account.move`

This PR also fix the foreign currency management which is not functional at the moment.

Also remove the verify=False on the calls to qonto.
There are no comment whatsoever indicating why it was done, and this is working fine without it.

The changes comes from https://github.com/OCA/bank-statement-import/pull/396/commits/21712f53406e3f1e0381c064c9f9e118b8615e42 

I don't know if the module is used already in v16, I guess/hope not, but it would be nice to review/merge this fast as the issues are importants.
@victoralmau @pedrobaeza @carolinafernandez-tecnativa 