### PR TITLE
[16.0][FIX] account_statement_import_sheet_file: skip header_lines for CSV

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -228,7 +228,7 @@ class AccountStatementImportSheetParser(models.TransientModel):
         if isinstance(csv_or_xlsx, tuple):
             rows = range(mapping.header_lines_skip_count, footer_line)
         else:
-            rows = csv_or_xlsx
+            rows = list(csv_or_xlsx)[label_line:]
 
         lines = []
         for index, row in enumerate(rows, label_line):


### PR DESCRIPTION
`header_lines_skip_count` should be skipped for CSV files as well

Lenghier esplanation. `enumerate()` second argument doesn't skip items. It just starts numbering them from a different start than 0. So if you want to skip N rows, you need to slice the list yourself.