### PR TITLE
[16.0][FIX] account_statement_import_base: sanitized acc number

### DIFF
--- a/account_statement_import_base/models/account_journal.py
+++ b/account_statement_import_base/models/account_journal.py
@@ -24,7 +24,10 @@ class AccountJournal(models.Model):
             ["acc_number", "partner_id"],
         )
         for partner_bank in partner_banks:
-            speeddict["account_number"][partner_bank["acc_number"]] = {
+            sanitized_acc_number = self._sanitize_bank_account_number(
+                partner_bank["acc_number"]
+            )
+            speeddict["account_number"][sanitized_acc_number] = {
                 "partner_id": partner_bank["partner_id"][0],
                 "partner_bank_id": partner_bank["id"],
             }


### PR DESCRIPTION
The field acc_number in the database is not sanitized by default.

This leads to account_bank_statement_line with an empty partner_id because the check done in _statement_line_import_update_hook() uses the sanitized_acc_number instead of the acc_number.

For a right comparison the sanitized version of the acc_number should be put in the speeddict.