### PR TITLE
[16][FIX] account_statement_import_online_paypal : search transaction with a 1 second margin to ensure it is found

### DIFF
--- a/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
+++ b/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
@@ -364,14 +364,15 @@ class OnlineBankStatementProviderPayPal(models.Model):
 
     def _paypal_get_transaction(self, token, transaction_id, timestamp):
         self.ensure_one()
-        transaction_date = timestamp.isoformat() + "Z"
+        transaction_date_ini = (timestamp - relativedelta(seconds=1)).isoformat() + "Z"
+        transaction_date_end = (timestamp + relativedelta(seconds=1)).isoformat() + "Z"
         url = (
             (self.api_base or PAYPAL_API_BASE)
             + "/v1/reporting/transactions"
             + ("?start_date=%s" "&end_date=%s" "&fields=all")
             % (
-                transaction_date,
-                transaction_date,
+                transaction_date_ini,
+                transaction_date_end,
             )
         )
         data = self._paypal_retrieve(url, token)


### PR DESCRIPTION
Workaround for https://github.com/OCA/bank-statement-import/issues/726 as proposed by @Roodin 
I propose it here so it is usable for people having this issue, but it may not be the best way.
I do not really know the module so I do not try something else but I do not understand why this is important : https://github.com/OCA/bank-statement-import/blob/16.0/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py#L235

Don't we have already the transaction in `first_transaction` variable?, why do we need to fetch it once again ?
Maybe @alexey-pelykh could enlighten me ?
