### PR TITLE
[15.0][FIX] account_statement_import_move_line: Set reference in bank statment lines

### DIFF
--- a/account_statement_import_move_line/models/account_move_line.py
+++ b/account_statement_import_move_line/models/account_move_line.py
@@ -19,7 +19,7 @@ class AccountMoveLine(models.Model):
             "amount": amount,
             "partner_id": self.partner_id.id,
             "statement_id": statement.id,
-            "payment_ref": self.ref,
+            "payment_ref": self.ref or self.name,
             "date": self.date_maturity,
             "currency_id": self.currency_id.id,
         }

--- a/account_statement_import_move_line/tests/test_account_bank_statement_import_move_line.py
+++ b/account_statement_import_move_line/tests/test_account_bank_statement_import_move_line.py
@@ -37,7 +37,6 @@ class TestAccountBankStatementImportMoveLine(TransactionCase):
                 "partner_id": cls.partner.id,
                 "move_type": "out_invoice",
                 "journal_id": cls.journal.id,
-                "ref": "Test",
                 "invoice_line_ids": [
                     (
                         0,


### PR DESCRIPTION
The ‘ref’ field is not visible on invoices of type ‘out_invoice’. In the tests, it is adding value to this field and therefore does not fail to create a bank statement line where the ‘payment_ref’ field is required. To solve this, the value of the ‘payment_ref’ field of the bank statement lines is set as the reference of a supplier invoice (‘ref’ in invoice lines) or as the reference of the payment ‘payment_reference’ (‘name’ in invoice lines).

cc @Tecnativa