### PR TITLE
[16.0][FIX] account_statement_import_online_gocardless : fix typing error…

### DIFF
--- a/account_statement_import_online_gocardless/wizards/online_bank_statement_provider_existing.py
+++ b/account_statement_import_online_gocardless/wizards/online_bank_statement_provider_existing.py
@@ -28,4 +28,4 @@ class OnlineBankStatementProviderExisting(models.TransientModel):
         provider._gocardless_finish_requisition(dry=True)
 
     def new_link(self):
-        return self.provider_id._gocardless_select_bank_instituion()
+        return self.provider_id._gocardless_select_bank_institution()


### PR DESCRIPTION
… in wizard/online_bank_statement_provider_existing.py new_link method. [link](https://github.com/OCA/bank-statement-import/blob/806d0b6c482a2b4c9ef0048f6b9ca885f6a9f7a3/account_statement_import_online_gocardless/wizards/online_bank_statement_provider_existing.py#L31)

Fixes #745
