### PR TITLE
[16.0][FIX] account_statement_import_online_gocardless : token/refresh endpoint

### DIFF
--- a/account_statement_import_online_gocardless/README.rst
+++ b/account_statement_import_online_gocardless/README.rst
@@ -129,6 +129,9 @@ Contributors
 * `Alusage <https://nicolas.alusage.fr>`__:
 
   * Nicolas JEUDY <https://github.com/njeudy>
+* `ArPol <https://arpol.fr>`__:
+
+  * Armand POLMARD <https://github.com/arpol-dev>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -84,17 +84,17 @@ class OnlineBankStatementProvider(models.Model):
             # Refresh token
             if (
                 self.gocardless_refresh_token
-                and now > self.gocardless_refresh_expiration
+                and now < self.gocardless_refresh_expiration
             ):
                 endpoint = "token/refresh"
+                request_data = {"refresh": self.gocardless_refresh_token}
             else:
                 endpoint = "token/new"
+                request_data = {"secret_id": self.username, "secret_key": self.password}
             _response, data = self._gocardless_request(
                 endpoint,
                 request_type="post",
-                data=json.dumps(
-                    {"secret_id": self.username, "secret_key": self.password}
-                ),
+                data=json.dumps(request_data),
                 basic_auth=True,
             )
             expiration_date = now + relativedelta(seconds=data.get("access_expires", 0))

--- a/account_statement_import_online_gocardless/readme/CONTRIBUTORS.rst
+++ b/account_statement_import_online_gocardless/readme/CONTRIBUTORS.rst
@@ -8,3 +8,6 @@
 * `Alusage <https://nicolas.alusage.fr>`__:
 
   * Nicolas JEUDY <https://github.com/njeudy>
+* `ArPol <https://arpol.fr>`__:
+
+  * Armand POLMARD <https://github.com/arpol-dev>

--- a/account_statement_import_online_gocardless/static/description/index.html
+++ b/account_statement_import_online_gocardless/static/description/index.html
@@ -494,6 +494,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Nicolas JEUDY &lt;<a class="reference external" href="https://github.com/njeudy">https://github.com/njeudy</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://arpol.fr">ArPol</a>:<ul>
+<li>Armand POLMARD &lt;<a class="reference external" href="https://github.com/arpol-dev">https://github.com/arpol-dev</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Correction of the endpoint token/refresh request datas that were not correctly set up, this request expects the refresh token but not the secret_id and secret_key.

Plus the behavior of the _gocardless_get_token method was calling the endpoint "token/new" instead of "token/refresh" in case of a non expired refresh token.