### PR TITLE
[FIX] account_statement_import_sheet_file: Erroneous values taken depending on the amount_type

### DIFF
--- a/account_statement_import_sheet_file/__manifest__.py
+++ b/account_statement_import_sheet_file/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Bank Statement TXT/CSV/XLSX Import",
     "summary": "Import TXT/CSV or XLSX files as Bank Statements in Odoo",
-    "version": "17.0.1.1.0",
+    "version": "17.0.1.2.0",
     "category": "Accounting",
     "website": "https://github.com/OCA/bank-statement-import",
     "author": "ForgeFlow, CorporateHub, Odoo Community Association (OCA)",

--- a/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
+++ b/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
@@ -78,8 +78,8 @@
                             <field name="amount_type" />
                             <field
                                 name="amount_column"
-                                invisible="amount_type == 'distinct_credit_debit'"
-                                required="amount_type != 'distinct_credit_debit'"
+                                invisible="amount_type != 'simple_value'"
+                                required="amount_type == 'simple_value'"
                             />
 
                             <field


### PR DESCRIPTION
The error originated from the lack of precision in the fields taken when selecting an amount_type. The first and most recurring issue was that when setting a value in the amount_column field, changing the amount_type caused this field to disappear, but the module continued referencing it, throwing an error if it was correctly set. This commit ensures that the value is taken based on the selected amount_type.