### PR TITLE
[16.0][IMP] account_statement_import_online: add option to enable or disable statement creation.

### DIFF
--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -385,6 +385,15 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
         self.assertEqual(statements[1].balance_end, 200)
         self.assertEqual(len(statements[1].line_ids), 1)
 
+    def test_dont_create_statement(self):
+        self.provider.statement_creation_mode = "monthly"
+        self.provider.create_statement = False
+        date_since = datetime(2024, 12, 1)
+        date_until = datetime(2024, 12, 31, 23, 59, 59)
+        self.provider.with_context(step={"days": 1})._pull(date_since, date_until)
+        self._getExpectedStatements(0)
+        self._getExpectedLines(31)
+
     def test_unlink_provider(self):
         """Unlink provider should clear fields on journal."""
         self.provider.unlink()

--- a/account_statement_import_online/views/online_bank_statement_provider.xml
+++ b/account_statement_import_online/views/online_bank_statement_provider.xml
@@ -83,6 +83,7 @@
                         </group>
                         <group name="configuration" string="Configuration">
                             <field name="statement_creation_mode" />
+                            <field name="create_statement" />
                             <field name="tz" />
                         </group>
                     </group>


### PR DESCRIPTION

Starting from Odoo 16, bank statements are optional. This commit introduces the option to create statements automatically or skip their creation.

TT52481
@Tecnativa @pedrobaeza Could you please review this