### PR TITLE
[FIX] account_statement_import_sheet_file: Reset fields based on the selected 'amount_type' value when its change

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
@@ -254,3 +254,17 @@ class AccountStatementImportSheetMapping(models.Model):
 
     def _get_column_delimiter_character(self):
         return self._decode_column_delimiter_character(self.delimiter)
+
+    @api.onchange("amount_type")
+    def _onchange_amount_type(self):
+        if self.amount_type == "simple_value":
+            self.debit_credit_column = False
+            self.amount_debit_column = False
+            self.amount_credit_column = False
+        elif self.amount_type == "absolute_value":
+            self.amount_column = False
+            self.amount_debit_column = False
+            self.amount_credit_column = False
+        elif self.amount_type == "distinct_credit_debit":
+            self.amount_column = False
+            self.debit_credit_column = False

--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -769,3 +769,37 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
         self.assertEqual(statement.balance_start, 0.0)
         self.assertEqual(statement.balance_end_real, 2291.5)
         self.assertEqual(statement.balance_end, 2291.5)
+
+    def test_onchange_amount_type_simple_value(self):
+        """Test that fields are reset when 'amount_type'
+        is set to 'simple_value'."""
+        self.sample_statement_map.amount_column = "Amount"
+        self.sample_statement_map.amount_type = "simple_value"
+        self.sample_statement_map._onchange_amount_type()
+        self.assertFalse(self.sample_statement_map.debit_credit_column)
+        self.assertFalse(self.sample_statement_map.amount_debit_column)
+        self.assertFalse(self.sample_statement_map.amount_credit_column)
+        self.assertEqual(self.sample_statement_map.amount_column, "Amount")
+
+    def test_onchange_amount_type_absolute_value(self):
+        """Test that fields are reset when 'amount_type'
+        is set to 'absolute_value'."""
+        self.sample_statement_map.debit_credit_column = "Amount"
+        self.sample_statement_map.amount_type = "absolute_value"
+        self.sample_statement_map._onchange_amount_type()
+        self.assertFalse(self.sample_statement_map.amount_column)
+        self.assertFalse(self.sample_statement_map.amount_debit_column)
+        self.assertFalse(self.sample_statement_map.amount_credit_column)
+        self.assertEqual(self.sample_statement_map.debit_credit_column, "Amount")
+
+    def test_onchange_amount_type_distinct_credit_debit(self):
+        """Test that fields are reset when 'amount_type'
+        is set to 'distinct_credit_debit'."""
+        self.sample_statement_map.amount_debit_column = "Debit"
+        self.sample_statement_map.amount_credit_column = "Credit"
+        self.sample_statement_map.amount_type = "distinct_credit_debit"
+        self.sample_statement_map._onchange_amount_type()
+        self.assertFalse(self.sample_statement_map.amount_column)
+        self.assertFalse(self.sample_statement_map.debit_credit_column)
+        self.assertEqual(self.sample_statement_map.amount_debit_column, "Debit")
+        self.assertEqual(self.sample_statement_map.amount_credit_column, "Credit")


### PR DESCRIPTION
When 'amount_type' is changed, related fields (such as amount_debit_column,amount_credit_column,debit_credit_column,amount_column) are not cleared, leading to potential inconsistencies in the values.

This commit fixes the issue by ensuring that when 'amount_type' is set to a new value, all the related fields are reset accordingly to avoid any residual values.

Steps to reproduce:
1. Start with the amount_type field set to "Simple Value", and ensure the "Amount Column" field is correctly configured, for example, with the value "Amount".
2. Change the amount_type field to "Distinct Credit/Debit Column", and set values for the "Debit Amount Column" and "Credit Amount Column"  fields, for example, "Debit" and "Credit", respectively.
3. Observe that the previously configured "Amount Column" field is not cleared, leading to potential inconsistencies in the data.


With this fix, related fields such as 'amount_column','debit_credit_column', 'amount_debit_column', and 'amount_credit_column' are correctly reset when 'amount_type' changes.

Video with the issue 
[Video](https://drive.google.com/file/d/1WJRmkW5Sdd6fqWio7VEpWEfjxox-kP6q/view)
