### PR TITLE
[16.0][FIX] account_statement_import_sheet_file: Prevent negative index in parser header

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -39,22 +39,22 @@ class AccountStatementImportSheetParser(models.TransientModel):
     _description = "Bank Statement Import Sheet Parser"
 
     @api.model
-    def parse_header(self, data_file, encoding, csv_options, header_lines_skip_count=0):
-        try:
-            workbook = xlrd.open_workbook(
-                file_contents=data_file,
-                encoding_override=encoding if encoding else None,
-            )
-            sheet = workbook.sheet_by_index(0)
-            values = sheet.row_values(header_lines_skip_count - 1)
-            return [str(value) for value in values]
-        except xlrd.XLRDError:
-            _logger.error("Pass this method")
-
-        data = StringIO(data_file.decode(encoding or "utf-8"))
-        csv_data = reader(data, **csv_options)
-        csv_data_lst = list(csv_data)
-        header = [value.strip() for value in csv_data_lst[header_lines_skip_count - 1]]
+    def parse_header(self, csv_or_xlsx, mapping):
+        if mapping.no_header:
+            return []
+        header_line = mapping.header_lines_skip_count
+        # prevent negative indexes
+        if header_line > 0:
+            header_line -= 1
+        if isinstance(csv_or_xlsx, tuple):
+            header = [
+                str(value).strip() for value in csv_or_xlsx[1].row_values(header_line)
+            ]
+        else:
+            [next(csv_or_xlsx) for _i in range(header_line)]
+            header = [value.strip() for value in next(csv_or_xlsx)]
+        if mapping.offset_column:
+            header = header[mapping.offset_column :]
         return header
 
     @api.model
@@ -177,22 +177,7 @@ class AccountStatementImportSheetParser(models.TransientModel):
                     ) from None
                 decoded_file = data_file.decode(detected_encoding)
             csv_or_xlsx = reader(StringIO(decoded_file), **csv_options)
-        header = False
-        if not mapping.no_header:
-            header_line = mapping.header_lines_skip_count
-            # prevent negative indexes
-            if header_line > 0:
-                header_line -= 1
-            if isinstance(csv_or_xlsx, tuple):
-                header = [
-                    str(value).strip()
-                    for value in csv_or_xlsx[1].row_values(header_line)
-                ]
-            else:
-                [next(csv_or_xlsx) for _i in range(header_line)]
-                header = [value.strip() for value in next(csv_or_xlsx)]
-            if mapping.offset_column:
-                header = header[mapping.offset_column :]
+        header = self.parse_header(csv_or_xlsx, mapping)
 
         # NOTE no seria necesario debit_column y credit_column ya que tenemos los
         # respectivos campos related

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -179,7 +179,10 @@ class AccountStatementImportSheetParser(models.TransientModel):
             csv_or_xlsx = reader(StringIO(decoded_file), **csv_options)
         header = False
         if not mapping.no_header:
-            header_line = mapping.header_lines_skip_count - 1
+            header_line = mapping.header_lines_skip_count
+            # prevent negative indexes
+            if header_line > 0:
+                header_line -= 1
             if isinstance(csv_or_xlsx, tuple):
                 header = [
                     str(value).strip()

--- a/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
+++ b/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
@@ -44,6 +44,7 @@
                             <div
                                 class="alert alert-warning"
                                 role="alert"
+                                colspan="2"
                                 attrs="{'invisible': [('no_header', '=', False)]}"
                             >
                                 <span


### PR DESCRIPTION
When importing an Excel file with a header and the field `header_lines_skip_count` is set to its default value (0), the header is retrieved using the -1 index (the last row).
complementary to commit https://github.com/OCA/bank-statement-import/commit/13285abe74d326153c8d0e74c21ddbdf3cdf17a0

UI Before
![image](https://github.com/user-attachments/assets/ea0c0726-961d-49be-b319-4b991af4d28c)
UI After
![image](https://github.com/user-attachments/assets/954a5df4-28c8-43f7-be77-bdd3a7a7e9ec)



TT52618
@Tecnativa @pedrobaeza @victoralmau @zaoral could you please review this