### PR TITLE
[IMP] account_statement_import_sheet_file: XLS[X] file can actually be HTML

### DIFF
--- a/account_statement_import_sheet_file/README.rst
+++ b/account_statement_import_sheet_file/README.rst
@@ -65,10 +65,10 @@ Changelog
 12.0.2.0.0
 ----------
 
-- [BREAKING] New mapping, please review mappings after upgrade.
-- [BREAKING] Different bank accounts have to be used per each currency.
-- [ADD] Support for both Statement and Activity reports.
-- [ADD] Separate fee and currency exchange parsing.
+-  [BREAKING] New mapping, please review mappings after upgrade.
+-  [BREAKING] Different bank accounts have to be used per each currency.
+-  [ADD] Support for both Statement and Activity reports.
+-  [ADD] Separate fee and currency exchange parsing.
 
 Bug Tracker
 ===========
@@ -92,25 +92,26 @@ Authors
 Contributors
 ------------
 
-- Alexis de Lattre <alexis.delattre@akretion.com>
-- Sebastien BEAU <sebastien.beau@akretion.com>
-- Katherine Zaoral
-- Tecnativa (https://www.tecnativa.com)
+-  Alexis de Lattre <alexis.delattre@akretion.com>
+-  Sebastien BEAU <sebastien.beau@akretion.com>
+-  Katherine Zaoral
+-  Tecnativa (https://www.tecnativa.com)
 
-  - Vicent Cubells
-  - Victor M.M. Torres
-  - Víctor Martínez
+   -  Vicent Cubells
+   -  Victor M.M. Torres
+   -  Víctor Martínez
 
-- ForgeFlow (https://www.forgeflow.com)
+-  ForgeFlow (https://www.forgeflow.com)
 
-  - Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
-  - Miquel Raïch Regué <miquel.raich@forgeflow.com>
+   -  Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
+   -  Miquel Raïch Regué <miquel.raich@forgeflow.com>
 
-- `CorporateHub <https://corporatehub.eu/>`__
+-  `CorporateHub <https://corporatehub.eu/>`__
 
-  - Alexey Pelykh <alexey.pelykh@corphub.eu>
+   -  Alexey Pelykh <alexey.pelykh@corphub.eu>
 
-- Sebastiano Picchi sebastiano.picchi@pytech.it
+-  Sebastiano Picchi sebastiano.picchi@pytech.it
+-  Simone Rubino
 
 Maintainers
 -----------

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -1,5 +1,6 @@
 # Copyright 2019 ForgeFlow, S.L.
 # Copyright 2020 CorporateHub (https://corporatehub.eu)
+# Copyright 2025 Simone Rubino
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import itertools
@@ -12,13 +13,15 @@ from decimal import Decimal
 from io import StringIO
 from os import path
 
+from lxml import etree
+
 from odoo import _, api, models
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
 try:
-    from csv import reader
+    from csv import reader, writer
 
     import xlrd
     from xlrd.xldate import xldate_as_datetime
@@ -161,11 +164,6 @@ class AccountStatementImportSheetParser(models.TransientModel):
             )
         except xlrd.XLRDError:
             csv_options = {}
-            csv_delimiter = mapping._get_column_delimiter_character()
-            if csv_delimiter:
-                csv_options["delimiter"] = csv_delimiter
-            if mapping.quotechar:
-                csv_options["quotechar"] = mapping.quotechar
             try:
                 decoded_file = data_file.decode(mapping.file_encoding or "utf-8")
             except UnicodeDecodeError:
@@ -176,6 +174,25 @@ class AccountStatementImportSheetParser(models.TransientModel):
                         _("No valid encoding was found for the attached file")
                     ) from None
                 decoded_file = data_file.decode(detected_encoding)
+            is_HTML = decoded_file.lower().lstrip().startswith("<html>")
+            if is_HTML:
+                # Convert to CSV and continue import as CSV
+                rows = etree.HTML(decoded_file).xpath("//table//tr")
+
+                csv_decoded_file = StringIO()
+                wr = writer(csv_decoded_file)
+                wr.writerow([col.text for col in rows[0].xpath("//th")])
+                wr.writerows(
+                    [[col.text for col in row.xpath(".//td")] for row in rows[1:]]
+                )
+                decoded_file = csv_decoded_file.getvalue()
+            else:
+                csv_delimiter = mapping._get_column_delimiter_character()
+                if csv_delimiter:
+                    csv_options["delimiter"] = csv_delimiter
+                if mapping.quotechar:
+                    csv_options["quotechar"] = mapping.quotechar
+
             csv_or_xlsx = reader(StringIO(decoded_file), **csv_options)
         header = self.parse_header(csv_or_xlsx, mapping)
 

--- a/account_statement_import_sheet_file/readme/CONTRIBUTORS.md
+++ b/account_statement_import_sheet_file/readme/CONTRIBUTORS.md
@@ -11,3 +11,4 @@
 - [CorporateHub](https://corporatehub.eu/)
   - Alexey Pelykh \<<alexey.pelykh@corphub.eu>\>
 - Sebastiano Picchi <sebastiano.picchi@pytech.it>
+- Simone Rubino

--- a/account_statement_import_sheet_file/static/description/index.html
+++ b/account_statement_import_sheet_file/static/description/index.html
@@ -465,6 +465,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Sebastiano Picchi <a class="reference external" href="mailto:sebastiano.picchi&#64;pytech.it">sebastiano.picchi&#64;pytech.it</a></li>
+<li>Simone Rubino</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_statement_import_sheet_file/tests/fixtures/sample_statement_html.xlsx
+++ b/account_statement_import_sheet_file/tests/fixtures/sample_statement_html.xlsx
@@ -1,0 +1,92 @@
+
+
+
+
+
+<html>
+<head>
+<style>
+#OUTLetFac * {
+	font-size:9pt;}
+#OUTLetFac thead, #OUTLetFac tfoot, #OUTLetFac tbody {
+	border:1px solid #000000;}
+#OUTLetFac thead th {
+	background: #e6e6e6;
+	border:solid 1px #ffffff;
+	color:#000000;
+	text-align:center;
+	vertical-align:middle;
+	font-weight:bold;
+	padding:5px;}
+#OUTLetFac tbody td, #OUTLetFac tbody th {
+	border:solid 1px #000000;
+	vertical-align:top;
+	padding:3px 20px 2px 10px;
+	color:#000000;
+	}
+#OUTLetFac .pari {
+	background-color:#ffffff;}
+#OUTLetFac tbody th {
+	text-align:left;}
+#OUTLetFac p.small {
+	padding:0px;}
+#OUTLetFac img {
+	border:0px;
+	padding:0px;}
+#OUTLetFac tfoot th{
+	border-top: solid 1px #003f6e;
+	border-bottom: solid 1px #000000;
+	color: #000000;
+	padding:5px 20px 5px 10px;	}
+#OUTLetFac .negativo {
+		color:red;}
+</style>
+</head>
+<body>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="OUTLetFac">
+	<table id="CCMO" class="table table-striped dataTable no-footer">
+<thead>
+<tr class="hover">
+<th class=" date" title="Date">Date</th>
+<th class="hidden-xs date" title="Currency Date">Currency Date</th>
+<th class="amountTd number" title="Amount">Amount</th>
+<th class="amountTd number" title="Amount Currency">Amount Currency</th>
+<th class="hidden-xs hidecol-sm text" title="Currency">Currency</th>
+<th class="text" title="Partner Name">Partner Name</th>
+<th class="text" title="Bank Account">Bank Account</th>
+<th class="break-xs text" title="Label">Label</th>
+
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="oCenter">01/15/2025</td>
+<td class="oCenter hidden-xs">01/15/2025</td>
+<td class="amount oRight negativo oRight amountTd">-200.20</td>
+<td class="amount oRight negativo oRight amountTd">-210.20</td>
+<td class="oCenter hidden-xs hidecol-sm">EUR</td>
+<td class="oLeft">Azure Interior</td>
+<td class="oLeft">123456789</td>
+<td class="oLeft break-xs">Line description</td>
+</tr>
+</tbody>
+</table>
+
+</div>
+
+</body>
+</html>

--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -1,8 +1,10 @@
 # Copyright 2019 ForgeFlow, S.L.
 # Copyright 2020 CorporateHub (https://corporatehub.eu)
+# Copyright 2025 Simone Rubino
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from base64 import b64encode
+from datetime import date
 from decimal import Decimal
 from os import path
 from unittest.mock import Mock
@@ -769,3 +771,40 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
         self.assertEqual(statement.balance_start, 0.0)
         self.assertEqual(statement.balance_end_real, 2291.5)
         self.assertEqual(statement.balance_end, 2291.5)
+
+    def test_import_html_file(self):
+        """Import an XLS[X] file that is actually an HTML file."""
+        journal = self.AccountJournal.create(
+            {
+                "name": "Bank",
+                "type": "bank",
+                "code": "BANK",
+                "currency_id": self.currency_usd.id,
+                "suspense_account_id": self.suspense_account.id,
+            }
+        )
+        data_file_path = "fixtures/sample_statement_html.xlsx"
+        data = self._data_file(data_file_path)
+        wizard = self.AccountStatementImport.with_context(journal_id=journal.id).create(
+            {
+                "statement_filename": data_file_path,
+                "statement_file": data,
+                "sheet_mapping_id": self.sample_statement_map.id,
+            }
+        )
+        wizard.with_context(
+            account_statement_import_sheet_file_test=True
+        ).import_file_button()
+        statement = self.AccountBankStatement.search([("journal_id", "=", journal.id)])
+        self.assertEqual(len(statement), 1)
+        self.assertRecordValues(
+            statement.line_ids,
+            [
+                {
+                    "date": date(2025, month=1, day=15),
+                    "payment_ref": "Line description",
+                    "partner_name": "Azure Interior",
+                    "amount": -200.20,
+                },
+            ],
+        )


### PR DESCRIPTION
I recently downloaded an XLS file that was actually an HTML file (they exist, check the file in tests/fixtures!) and the module **account_statement_import_sheet_file** wasn't able to import it.
With this PR, it is possible to import such files.

Most of the README edits happened automatically running pre-commit.