### PR TITLE
[14.0][IMP] ensure currency name comparison is case-insensitive

### DIFF
--- a/account_statement_import_txt_xlsx/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_txt_xlsx/models/account_statement_import_sheet_parser.py
@@ -276,7 +276,7 @@ class AccountStatementImportSheetParser(models.TransientModel):
             else None
         )
 
-        if currency != currency_code:
+        if currency.lower() != currency_code.lower():
             return {}
 
         if isinstance(timestamp, str):


### PR DESCRIPTION
Avoid skipping lines just because 'eur' != 'EUR'