### PR TITLE
[16.0][imp][account_statement_import_online_gocardless]: add hook to construct to unique transaction id

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -367,11 +367,7 @@ class OnlineBankStatementProvider(models.Model):
                     "date": current_date,
                     "ref": partner_name or "/",
                     "payment_ref": payment_ref,
-                    "unique_import_id": (
-                        tr.get("entryReference")
-                        or tr.get("transactionId")
-                        or tr.get("internalTransactionId")
-                    ),
+                    "unique_import_id": self._gocardless_get_unique_import_id(tr),
                     "amount": amount_currency,
                     "account_number": account_number,
                     "partner_name": partner_name,
@@ -380,6 +376,13 @@ class OnlineBankStatementProvider(models.Model):
                 }
             )
         return res, {}
+
+    def _gocardless_get_unique_import_id(self, tr):
+        return (
+            tr.get("entryReference")
+            or tr.get("transactionId")
+            or tr.get("internalTransactionId")
+        )
 
     def _gocardless_get_note(self, tr):
         """Override to get different notes."""


### PR DESCRIPTION
The improvement is to add better extensibility to the module to cover situations such as https://github.com/OCA/bank-statement-import/pull/758.

@etobella @pedrobaeza 