### PR TITLE
[16.0][FIX] account_statement_import_file: fix attachment creation

### DIFF
--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -4,7 +4,7 @@
 import base64
 import logging
 
-from odoo import _, api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 
 from odoo.addons.base.models.res_bank import sanitize_account_number
@@ -39,7 +39,6 @@ class AccountStatementImport(models.TransientModel):
                     "only contains already imported transactions."
                 )
             )
-        self.env["ir.attachment"].create(self._prepare_create_attachment(result))
         return result
 
     def import_file_button(self):
@@ -65,15 +64,10 @@ class AccountStatementImport(models.TransientModel):
             return action_with_notif
         return action
 
-    def _prepare_create_attachment(self, result):
-        # Attach to first bank statement
-        res_id = result["statement_ids"][0]
-        st = self.env["account.bank.statement"].browse(res_id)
+    def _prepare_create_attachment(self, journal):
         vals = {
             "name": self.statement_filename,
-            "res_id": res_id,
-            "company_id": st.company_id.id,
-            "res_model": "account.bank.statement",
+            "company_id": journal.company_id.id,
             "datas": self.statement_file,
         }
         return vals
@@ -290,6 +284,9 @@ class AccountStatementImport(models.TransientModel):
         speeddict = journal._statement_line_import_speeddict()
         for st_vals in stmts_vals:
             st_vals["journal_id"] = journal.id
+            attach_vals = self._prepare_create_attachment(journal)
+            if attach_vals:
+                st_vals["attachment_ids"] = [Command.create(attach_vals)]
             for lvals in st_vals["transactions"]:
                 lvals["journal_id"] = journal.id
                 journal._statement_line_import_update_unique_import_id(


### PR DESCRIPTION
BEFORE :

![bug_import](https://github.com/user-attachments/assets/3bbbf70c-ca6d-49bd-9f48-66f7d9e1da02)

AFTER : 

![fixed_st_import](https://github.com/user-attachments/assets/910e20e8-511f-416b-a6fa-727dc86af362)

Cause : in v14/15, account.bank.statement inherited mail.thread and we were using the chatter to display the attachments. cf https://github.com/odoo/odoo/blob/14.0/addons/account/models/account_bank_statement.py#L119

starting from v16, account.bank.statement didn't inherit mail.thread any more and a new M2M field attachment_ids was added, cf https://github.com/odoo/odoo/blob/16.0/addons/account/models/account_bank_statement.py#L100. But the code in account_statement_import_file was not updated accordingly.

If this PR is approved, I'll forward port to v17 and v18.