### PR TITLE
[16.0][FIX] account_statement_import_online*: Post-install test + fallback to load CoA

### DIFF
--- a/account_statement_import_online_gocardless/tests/test_account_statement_import_online_gocardless.py
+++ b/account_statement_import_online_gocardless/tests/test_account_statement_import_online_gocardless.py
@@ -6,7 +6,7 @@ from unittest import mock
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 _module_ns = "odoo.addons.account_statement_import_online_gocardless"
 _provider_class = (
@@ -14,10 +14,20 @@ _provider_class = (
 )
 
 
+@tagged("post_install", "-at_install")
 class TestAccountBankAccountStatementImportOnlineGocardless(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.now = fields.Datetime.now()
         cls.currency_eur = cls.env.ref("base.EUR")
         cls.currency_eur.write({"active": True})


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with error:

odoo.exceptions.UserError: You can't create a new statement line without a suspense account set on the ... journal.

provoked by the lack of a CoA installed.

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA, and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`) easily, so we put little code to select the first available CoA.

@Tecnativa