### PR TITLE
[16.0][FIX] account_statement_import_txt_xlsx: currency comparison case-insensitive

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -318,7 +318,7 @@ class AccountStatementImportSheetParser(models.TransientModel):
                 if columns["bank_account_column"]
                 else None
             )
-            if currency != currency_code:
+            if currency.lower() != currency_code.lower():
                 continue
 
             if isinstance(timestamp, str):


### PR DESCRIPTION
Avoid skipping lines just because 'eur' != 'EUR'
Ref.: https://github.com/OCA/bank-statement-import/pull/764