### PR TITLE
[16.0][IMP] Support Multi-Currency Bank Accounts in `account_statement_import_file`

### DIFF
--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -223,8 +223,11 @@ class AccountStatementImport(models.TransientModel):
                         sanitized_account_number,
                     ),
                 ],
-                limit=1,
             )
+            if len(journal) > 1:
+                journal = journal.filtered(
+                    lambda j: (j.currency_id or company.currency_id) == currency
+                )[:1]
             ctx_journal_id = self.env.context.get("journal_id")
             if journal and ctx_journal_id and journal.id != ctx_journal_id:
                 ctx_journal = journal_obj.browse(ctx_journal_id)


### PR DESCRIPTION
**`account_statement_import_file`: Support multiple journals (one per currency) for the same bank account number.**  

Our bank accounts operate in a *multi-currency* setup, meaning a single account number corresponds to distinct *sub-accounts*, each handling a different currency. We receive separate bank statement files for each sub-account, but the current module cannot handle this correctly—it selects only the first journal matching the account number.  

This PR addresses the issue by selecting *all* matching journals and, if necessary, further filtering them by currency.