### PR TITLE
[17.0][FIX] account_statement_import_online_gocardless: Swap bookingDate and valueDate

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -332,7 +332,7 @@ class OnlineBankStatementProvider(models.Model):
         currencies_cache = {}
         for tr in transactions.get("transactions", {}).get("booked", []):
             # Reference: https://developer.gocardless.com/bank-account-data/transactions
-            string_date = tr.get("bookingDate") or tr.get("valueDate")
+            string_date = tr.get("valueDate") or tr.get("bookingDate")
             # CHECK ME: if there's not date string, is transaction still valid?
             if not string_date:
                 continue


### PR DESCRIPTION
Forward-port of #782

This fixes behavior when there are debit card transactions with bookingDate behind the actual valueDate. In current situation, this leads to be discarded later in here:

https://github.com/OCA/bank-statement-import/blob/e91e28117d5ae3fbb5e1fb168b734f6690689433/account_statement_import_online/models/online_bank_statement_provider.py#L345-L351

@Tecnativa 