### PR TITLE
[16.0][FIX]account_statement_import_sheet_file: remove useless class

### DIFF
--- a/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
+++ b/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
@@ -21,7 +21,7 @@
             <form>
                 <sheet>
                     <div class="oe_title">
-                        <label for="name" class="oe_edit_only" />
+                        <label for="name" />
                         <h1>
                             <field name="name" />
                         </h1>


### PR DESCRIPTION
In odoo 16.0 the class `oe_edit_only` serves no purpose. With this PR we remove it, avoiding possible confusion