### PR TITLE
[16.0][IMP] account_statement_import_file: Allow to pass context on vals

### DIFF
--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -335,9 +335,10 @@ class AccountStatementImport(models.TransientModel):
                         vals["sequence"] = seq
                 # Remove values that won't be used to create records
                 st_vals.pop("transactions", None)
+                context = st_vals.pop("creation_context", {})
                 # Create the statement with lines
                 st_vals["line_ids"] = [[0, False, line] for line in st_lines_to_create]
-                statement = abs_obj.create(st_vals)
+                statement = abs_obj.with_context(**context).create(st_vals)
                 statement_ids.append(statement.id)
 
         if not statement_ids:


### PR DESCRIPTION
This hook is useful to pass some context values depending on the file.