### PR TITLE
[IMP] account_statement_import_file: create statement lines in bundles

### DIFF
--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -349,7 +349,7 @@ class AccountStatementImport(models.TransientModel):
                         {
                             "line_ids": [
                                 [0, False, line]
-                                for line in st_lines_to_create[x : x + 99]
+                                for line in st_lines_to_create[x : x + 100]
                             ]
                         }
                     )

--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -343,8 +343,16 @@ class AccountStatementImport(models.TransientModel):
                 st_vals.pop("transactions", None)
                 context = st_vals.pop("creation_context", {})
                 # Create the statement with lines
-                st_vals["line_ids"] = [[0, False, line] for line in st_lines_to_create]
                 statement = abs_obj.with_context(**context).create(st_vals)
+                for x in range(0, len(st_lines_to_create), 100):
+                    statement.write(
+                        {
+                            "line_ids": [
+                                [0, False, line]
+                                for line in st_lines_to_create[x : x + 99]
+                            ]
+                        }
+                    )
                 statement_ids.append(statement.id)
 
         if not statement_ids:


### PR DESCRIPTION
During the import of files with many extract lines errors may occur in the orm. To avoid this error  creates lines in groups of 100.