### PR TITLE
[16.0][FIX] account_statement_import_online_gocardless: Pass correct provider ID

### DIFF
--- a/account_statement_import_online_gocardless/static/src/js/select_bank_widget.js
+++ b/account_statement_import_online_gocardless/static/src/js/select_bank_widget.js
@@ -97,7 +97,7 @@ odoo.define(
                                     ._rpc({
                                         model: "online.bank.statement.provider",
                                         method: "action_check_gocardless_agreement",
-                                        args: [[self.context.active_id]],
+                                        args: [[self.context.provider_id]],
                                     })
                                     .then(function (redirect_url) {
                                         if (redirect_url !== undefined) {


### PR DESCRIPTION
Using `active_id context` key may lead to incorrect values, as it depends on the wizard starting URL. As we have the provider ID already in a context key, let's use it to always make sure it works.

@Tecnativa TT55399