### PR TITLE
[16.0][IMP] account_statement_import_online: Pull wizard with dates and one fetch

### DIFF
--- a/account_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_statement_import_online/models/online_bank_statement_provider.py
@@ -188,13 +188,15 @@ class OnlineBankStatementProvider(models.Model):
                 )[0][1],
             }
 
-    def _pull(self, date_since, date_until):
+    def _pull(self, date_since, date_until, one_fetch=False):
         """Pull data for all providers within requested period."""
         is_scheduled = self.env.context.get("scheduled")
         debug = self.env.context.get("account_statement_online_import_debug")
         debug_data = []
         for provider in self:
             statement_date_since = provider._get_statement_date_since(date_since)
+            if one_fetch:
+                statement_date_since = date_since
             while statement_date_since < date_until:
                 # Note that statement_date_until is exclusive, while date_until is
                 # inclusive. So if we have daily statements date_until might
@@ -202,6 +204,8 @@ class OnlineBankStatementProvider(models.Model):
                 statement_date_until = (
                     statement_date_since + provider._get_statement_date_step()
                 )
+                if one_fetch:
+                    statement_date_until = date_until
                 try:
                     data = provider._obtain_statement_data(
                         statement_date_since, statement_date_until

--- a/account_statement_import_online/wizards/online_bank_statement_pull_wizard.py
+++ b/account_statement_import_online/wizards/online_bank_statement_pull_wizard.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import pprint
+from datetime import datetime
 
 from odoo import fields, models
 
@@ -12,15 +13,13 @@ class OnlineBankStatementPullWizard(models.TransientModel):
     _name = "online.bank.statement.pull.wizard"
     _description = "Online Bank Statement Pull Wizard"
 
-    date_since = fields.Datetime(
-        string="From",
-        required=True,
-        default=fields.Datetime.now,
-    )
-    date_until = fields.Datetime(
-        string="To",
-        required=True,
-        default=fields.Datetime.now,
+    date_since = fields.Date(string="From", required=True, default=fields.Date.today)
+    date_until = fields.Date(string="To", required=True, default=fields.Date.today)
+    one_fetch = fields.Boolean(
+        string="One fetch",
+        help="If checked, retrieve the whole interval in only one request to the "
+        "provider. This is useful if the provider sets request limits.",
+        default=True,
     )
 
     def _get_provider(self):
@@ -35,10 +34,20 @@ class OnlineBankStatementPullWizard(models.TransientModel):
             provider = active_record
         return provider
 
+    def _get_datetimes(self):
+        """Return the datetime values for the entered dates, including whole starting
+        and ending days.
+        """
+        self.ensure_one()
+        since = datetime.combine(self.date_since, datetime.min.time())
+        until = datetime.combine(self.date_until, datetime.max.time())
+        return since, until
+
     def action_pull(self):
         """Pull statements from provider and then show list of statements."""
         provider = self._get_provider()
-        provider._pull(self.date_since, self.date_until)
+        since, until = self._get_datetimes()
+        provider._pull(since, until, one_fetch=self.one_fetch)
         action = self.env.ref("account.action_bank_statement_tree").sudo().read([])[0]
         action["domain"] = [("journal_id", "=", provider.journal_id.id)]
         return action
@@ -46,10 +55,10 @@ class OnlineBankStatementPullWizard(models.TransientModel):
     def action_debug(self):
         """Pull statements in debug and show result."""
         provider = self._get_provider().with_context(
-            active_test=False,
-            account_statement_online_import_debug=True,
+            active_test=False, account_statement_online_import_debug=True
         )
-        data = provider._pull(self.date_since, self.date_until)
+        since, until = self._get_datetimes()
+        data = provider._pull(since, until, one_fetch=self.one_fetch)
         wizard = self.env["online.bank.statement.pull.debug"].create(
             {"data": pprint.pformat(data)}
         )

--- a/account_statement_import_online/wizards/online_bank_statement_pull_wizard.xml
+++ b/account_statement_import_online/wizards/online_bank_statement_pull_wizard.xml
@@ -13,6 +13,7 @@
                 <group name="main">
                     <field name="date_since" />
                     <field name="date_until" />
+                    <field name="one_fetch" />
                 </group>
                 <footer>
                     <button

--- a/account_statement_import_online_gocardless/tests/test_account_statement_import_online_gocardless.py
+++ b/account_statement_import_online_gocardless/tests/test_account_statement_import_online_gocardless.py
@@ -126,6 +126,7 @@ class TestAccountBankAccountStatementImportOnlineGocardless(common.TransactionCa
         vals = {
             "date_since": "2020-10-30",
             "date_until": "2020-11-11",
+            "one_fetch": False,
         }
         wizard = (
             self.env["online.bank.statement.pull.wizard"]

--- a/account_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
+++ b/account_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
@@ -35,7 +35,7 @@ class OnlineBankStatementProvider(models.Model):
             ("ponto", "MyPonto.com"),
         ]
 
-    def _pull(self, date_since, date_until):
+    def _pull(self, date_since, date_until, one_fetch=False):
         """For Ponto the pulling of data will not be grouped by statement.
 
         Instead we will pull data from the last available backwards.
@@ -52,7 +52,7 @@ class OnlineBankStatementProvider(models.Model):
         debug = self.env.context.get("account_statement_online_import_debug")
         debug_data = []
         data = super(OnlineBankStatementProvider, self - ponto_providers)._pull(
-            date_since, date_until
+            date_since, date_until, one_fetch=one_fetch
         )
         if debug:
             debug_data += data


### PR DESCRIPTION
This commit improves the provider pull wizard in 2 ways:

- It asks for dates instead of datetimes, as at the end, the minimum pull unit is the whole day, and it was very confusing for the user to select times without knowing that behind the scenes, the whole day will be pulled. Now, the user selects only the day. Quicker and cleaner...
- It includes a check "One fetch", that instructs the pull method to ask to the provider the whole interval in one shot. This way, you don't consume the request rate limits for the providers with them, or only due to speed purposes. It's checked by default, as it's the more natural way of fetching an interval on demand.

@Tecnativa TT55399