### PR TITLE
[18.0][IMP] account_statement_import_online: add option to enable or disabl…

### DIFF
--- a/account_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_statement_import_online/models/online_bank_statement_provider.py
@@ -26,6 +26,10 @@ class OnlineBankStatementProvider(models.Model):
 
     company_id = fields.Many2one(related="journal_id.company_id", store=True)
     active = fields.Boolean(default=True)
+    create_statement = fields.Boolean(
+        default=True,
+        help="Create statements for the downloaded transactions automatically or not.",
+    )
     name = fields.Char(compute="_compute_name", store=True)
     journal_id = fields.Many2one(
         comodel_name="account.journal",
@@ -76,11 +80,12 @@ class OnlineBankStatementProvider(models.Model):
     )
     statement_creation_mode = fields.Selection(
         selection=[
-            ("daily", "Daily statements"),
-            ("weekly", "Weekly statements"),
-            ("monthly", "Monthly statements"),
+            ("daily", "Day"),
+            ("weekly", "Week"),
+            ("monthly", "Month"),
         ],
         default="daily",
+        string="Transactions interval to obtain",
         required=True,
     )
     api_base = fields.Char()
@@ -303,6 +308,8 @@ class OnlineBankStatementProvider(models.Model):
         """Final creation of statement if new, else write."""
         AccountBankStatement = self.env["account.bank.statement"]
         is_scheduled = self.env.context.get("scheduled")
+        if not self.create_statement:
+            return self._online_create_statement_lines(statement_values)
         if is_scheduled:
             AccountBankStatement = AccountBankStatement.with_context(
                 tracking_disable=True,
@@ -323,6 +330,17 @@ class OnlineBankStatementProvider(models.Model):
         else:
             statement.write(statement_values)
         return statement
+
+    def _online_create_statement_lines(self, statement_values):
+        AccountBankStatementLine = self.env["account.bank.statement.line"]
+        is_scheduled = self.env.context.get("scheduled")
+        if is_scheduled:
+            AccountBankStatementLine = AccountBankStatementLine.with_context(
+                tracking_disable=True,
+            )
+        lines = [line[2] for line in statement_values.get("line_ids", [])]
+        AccountBankStatementLine.create(lines)
+        return self.env["account.bank.statement"]  # Return empty statement
 
     def _get_statement_filtered_lines(
         self,

--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -390,6 +390,15 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
         self.assertEqual(statements[1].balance_end, 200)
         self.assertEqual(len(statements[1].line_ids), 1)
 
+    def test_dont_create_statement(self):
+        self.provider.statement_creation_mode = "monthly"
+        self.provider.create_statement = False
+        date_since = datetime(2024, 12, 1)
+        date_until = datetime(2024, 12, 31, 23, 59, 59)
+        self.provider.with_context(step={"days": 1})._pull(date_since, date_until)
+        self._getExpectedStatements(0)
+        self._getExpectedLines(31)
+
     def test_unlink_provider(self):
         """Unlink provider should clear fields on journal."""
         self.provider.unlink()

--- a/account_statement_import_online/views/online_bank_statement_provider.xml
+++ b/account_statement_import_online/views/online_bank_statement_provider.xml
@@ -83,6 +83,7 @@
                         </group>
                         <group name="configuration" string="Configuration">
                             <field name="statement_creation_mode" />
+                            <field name="create_statement" />
                             <field name="tz" />
                         </group>
                     </group>


### PR DESCRIPTION
…e statement creation.

Starting from Odoo 16, bank statements are optional. This commit introduces the option to create statements automatically or skip their creation.

TT52481

Forward-port of https://github.com/OCA/bank-statement-import/pull/799

@Tecnativa @pedrobaeza @victoralmau please take a look