### PR TITLE
[17.0][IMP] account_statement_import_sheet_file: Current year if no year

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -348,6 +348,14 @@ class AccountStatementImportSheetParser(models.TransientModel):
 
             if isinstance(timestamp, str):
                 timestamp = datetime.strptime(timestamp, mapping.timestamp_format)
+                if timestamp.year == 1900:
+                    # No year indicated, so put the current or previous one depending
+                    # on the current month (i.e. in January, importing December)
+                    now = datetime.now()
+                    year = now.year
+                    if timestamp.month > now.month:
+                        year -= 1
+                    timestamp = timestamp.replace(year=year)
 
             if balance:
                 balance = self._parse_decimal(balance, mapping)


### PR DESCRIPTION
There can be files where the date is only expressed with day and month, but no year. You put in that case a timestamp expression like '%d/%m'. For that, strptime parses the content and return the day and month in the year 1900.

This code checks that condition and replace the year by the current one, as clearly 1900 is not a year to post transactions. There's also logic for putting previous year if the current month is lower than the imported one (i.e., current month is January and you are importing December).

@Tecnativa 