### PR TITLE
[16.0][FIX] account_statement_import_online_gocardless: Don't reuse other account agreement

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -122,6 +122,7 @@ class OnlineBankStatementProvider(models.Model):
         other = self.search(
             [
                 ("service", "=", "gocardless"),
+                ("username", "=", self.username),
                 ("gocardless_requisition_id", "!=", False),
                 ("journal_id.bank_id", "=", self.journal_id.bank_id.id),
                 ("id", "!=", self.id),


### PR DESCRIPTION
If you are using several GoCardless accounts, we can't reuse the agreement from other account.

@Tecnativa 