### PR TITLE
[16.0][IMP] account_statement_import_online_gocardless: Be aware of rate limits

### DIFF
--- a/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
+++ b/account_statement_import_online_gocardless/models/online_bank_statement_provider.py
@@ -69,6 +69,8 @@ class OnlineBankStatementProvider(models.Model):
             headers=self._gocardless_get_headers(basic=basic_auth),
             timeout=REQUESTS_TIMEOUT,
         )
+        if response.status_code == 429:  # Rate limit overpassed
+            raise UserError(json.loads(response.text)["detail"])
         if response.status_code in [200, 201]:
             content = json.loads(response.text)
         return response, content


### PR DESCRIPTION
GoCardless is imposing certain rate limits to their API usage, so we should be aware of them for not having false positives of a query with no activity returned.

https://bankaccountdata.zendesk.com/hc/en-gb/articles/11529637772188-Bank-Account-Data-API-Rate-Limits

We triggered an exception for interrupting the flow, that serves for both interactive and scheduled download, putting the message in the first case, and logging the exception in the provider chatter in the second, and not advancing in the update interval.

Example of the returned message:

"The rate limit for this resource is 4/day. Please try again in 85092 seconds"

@Tecnativa TT56795