### PR TITLE
[14.0][FIX] account_statement_import_online_wise: use foreign_currency_id

### DIFF
--- a/account_statement_import_online_wise/models/online_bank_statement_provider_transferwise.py
+++ b/account_statement_import_online_wise/models/online_bank_statement_provider_transferwise.py
@@ -244,7 +244,7 @@ class OnlineBankStatementProviderTransferwise(models.Model):
                 line.update(
                     {
                         "amount_currency": str(other_amount_value),
-                        "currency_id": other_currency.id,
+                        "foreign_currency_id": other_currency.id,
                     }
                 )
         lines = [line]

--- a/account_statement_import_online_wise/tests/test_account_statement_import_online_transferwise.py
+++ b/account_statement_import_online_wise/tests/test_account_statement_import_online_transferwise.py
@@ -534,7 +534,7 @@ edF6byMgXSzgOWYuRPXwmHpBQV0GiexQUAxVyUzaVWfil69LaFfXaw==
                 "partner_name": "Paypal *XX",
                 "unique_import_id": "DEBIT-CARD-123456789-946684800",
                 "amount_currency": "-567.89",
-                "currency_id": self.currency_usd.id,
+                "foreign_currency_id": self.currency_usd.id,
             },
         )
         self.assertEqual(
@@ -600,7 +600,7 @@ edF6byMgXSzgOWYuRPXwmHpBQV0GiexQUAxVyUzaVWfil69LaFfXaw==
                 "account_number": "(ADBCDEF) 0000000000000000",
                 "amount": "-265.34",
                 "amount_currency": "-297.00",
-                "currency_id": self.currency_usd.id,
+                "foreign_currency_id": self.currency_usd.id,
                 "unique_import_id": "DEBIT-TRANSFER-123456789-946684800",
             },
         )
@@ -706,7 +706,7 @@ edF6byMgXSzgOWYuRPXwmHpBQV0GiexQUAxVyUzaVWfil69LaFfXaw==
                 "payment_ref": "BALANCE-123456789: Converted 7.93 USD to 6.93 EUR",
                 "amount": "6.93",
                 "amount_currency": "7.93",
-                "currency_id": self.currency_usd.id,
+                "foreign_currency_id": self.currency_usd.id,
                 "unique_import_id": "CREDIT-BALANCE-123456789-946684800",
             },
         )
@@ -764,7 +764,7 @@ edF6byMgXSzgOWYuRPXwmHpBQV0GiexQUAxVyUzaVWfil69LaFfXaw==
                 "payment_ref": "BALANCE-123456789: Converted 7.93 USD to 6.93 EUR",
                 "amount": "-7.88",
                 "amount_currency": "-6.93",
-                "currency_id": self.currency_eur.id,
+                "foreign_currency_id": self.currency_eur.id,
                 "unique_import_id": "DEBIT-BALANCE-123456789-946684800",
             },
         )


### PR DESCRIPTION
Foreign currency transactions failed to load because of the following check in Odoo:

https://github.com/OCA/OCB/blob/1bbabffeead7a00defe29942a5c9ecf574393dd6/addons/account/models/account_bank_statement.py#L851

Which says that when amount_currency is filled, foreign_currency_id should be filled too, then throws a breaking error:

```
  File "/odoo/lib/python3.9/site-packages/odoo/addons/account_statement_import_online/models/online_bank_statement_provider.py", line 256, in _create_or_update_statement
    statement.write(statement_values)
(...)
  File "/odoo/lib/python3.9/site-packages/odoo/addons/account/models/account_bank_statement.py", line 851, in _check_amounts_currencies
    raise ValidationError(_("You can't provide an amount in foreign currency without specifying a foreign currency."))
```