### PR TITLE
[16.0][FIX] account_statement_import_file: Corrects amounts with currencies when importing wigh foreign_currency

### DIFF
--- a/account_statement_import_file/models/__init__.py
+++ b/account_statement_import_file/models/__init__.py
@@ -1,1 +1,2 @@
 from . import account_journal
+from . import account_bank_statement_line

--- a/account_statement_import_file/models/__init__.py
+++ b/account_statement_import_file/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_journal
+from . import account_move
 from . import account_bank_statement_line

--- a/account_statement_import_file/models/account_bank_statement_line.py
+++ b/account_statement_import_file/models/account_bank_statement_line.py
@@ -1,0 +1,33 @@
+from odoo import models
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = "account.bank.statement.line"
+
+    def _get_amounts_with_currencies(self):
+        (
+            company_amount,
+            company_currency,
+            journal_amount,
+            journal_currency,
+            transaction_amount,
+            foreign_currency,
+        ) = super()._get_amounts_with_currencies()
+        if self.env.context.get("from_stmt_import", False) and self.foreign_currency_id:
+            if self.foreign_currency_id == company_currency:
+                company_currency = self.journal_id.company_id.currency_id
+                journal_currency = self.journal_id.currency_id or company_currency
+                company_amount = self.amount_currency
+                foreign_currency = journal_currency
+                transaction_amount = self.amount
+            elif journal_currency == company_currency:
+                journal_amount = self.amount_currency
+                journal_currency = foreign_currency
+        return (
+            company_amount,
+            company_currency,
+            journal_amount,
+            journal_currency,
+            transaction_amount,
+            foreign_currency,
+        )

--- a/account_statement_import_file/models/account_move.py
+++ b/account_statement_import_file/models/account_move.py
@@ -1,0 +1,24 @@
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.depends("journal_id", "statement_line_id")
+    def _compute_currency_id(self):
+        res = super()._compute_currency_id()
+        if self.env.context.get("from_stmt_import", False):
+            for invoice in self:
+                if (
+                    invoice.statement_line_id.foreign_currency_id
+                    and invoice.statement_line_id.foreign_currency_id
+                    == invoice.journal_id.company_id.currency_id
+                ):
+                    currency = (
+                        invoice.journal_id.currency_id
+                        or invoice.statement_line_id.foreign_currency_id
+                        or invoice.currency_id
+                        or invoice.journal_id.company_id.currency_id
+                    )
+                    invoice.currency_id = currency
+        return res

--- a/account_statement_import_file/tests/__init__.py
+++ b/account_statement_import_file/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_statement_import_file

--- a/account_statement_import_file/tests/test_account_statement_import_file.py
+++ b/account_statement_import_file/tests/test_account_statement_import_file.py
@@ -1,0 +1,45 @@
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestAccountStatementImportFile(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.eur_currency = cls.env.ref("base.EUR")
+        cls.usd_currency = cls.env.ref("base.USD")
+        cls.company = cls.env.company
+        cls.bank_journal_eur = cls.env["account.journal"].create(
+            {
+                "name": "Bank EUR Test",
+                "type": "bank",
+                "code": "BNK_T",
+                "currency_id": cls.eur_currency.id,
+            }
+        )
+
+    def test_eur_journal_usd_foreign(self):
+        statement_line = (
+            self.env["account.bank.statement.line"]
+            .with_context(from_stmt_import=True)
+            .create(
+                {
+                    "journal_id": self.bank_journal_eur.id,
+                    "amount": 100.00,
+                    "foreign_currency_id": self.usd_currency.id,
+                    "amount_currency": 110.00,
+                }
+            )
+        )
+        move = statement_line.move_id
+        self.assertTrue(move)
+        bank_line = move.line_ids.filtered(
+            lambda line: line.account_id.account_type == "asset_cash"
+        )
+        counterpart_line = move.line_ids - bank_line
+        self.assertEqual(counterpart_line.credit, 110.0)
+        self.assertEqual(counterpart_line.amount_currency, -100.0)
+        self.assertEqual(bank_line.debit, 110.0)
+        self.assertEqual(bank_line.amount_currency, 100.0)

--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -117,7 +117,9 @@ class AccountStatementImport(models.TransientModel):
         # Prepare statement data to be used for bank statements creation
         stmts_vals = self._complete_stmts_vals(stmts_vals, journal, account_number)
         # Create the bank statements
-        self._create_bank_statements(stmts_vals, result)
+        self.with_context(from_stmt_import=True)._create_bank_statements(
+            stmts_vals, result
+        )
         # Now that the import worked out, set it as the bank_statements_source
         # of the journal
         if journal.bank_statements_source != "file_import_oca":


### PR DESCRIPTION
When importing statements with specific foreign currency and amount, Journal Entry created is not entirely correct.
<img width="1069" height="594" alt="image" src="https://github.com/user-attachments/assets/701d8343-38cc-417d-a5e5-0470054e6a6f" />

When applying this fix, journal entry is created as expected:
<img width="1069" height="594" alt="image" src="https://github.com/user-attachments/assets/8fe93a96-3593-46e1-82fe-e41861add567" />
