### PR TITLE
[17.0][FIX] account_statement_import_online_gocardless: Date type selectable

### DIFF
--- a/account_statement_import_online_gocardless/view/online_bank_statement_provider.xml
+++ b/account_statement_import_online_gocardless/view/online_bank_statement_provider.xml
@@ -21,6 +21,11 @@
                         required="service == 'gocardless'"
                     />
                     <field
+                        name="gocardless_date_type"
+                        invisible="service != 'gocardless'"
+                        required="service == 'gocardless'"
+                    />
+                    <field
                         name="gocardless_requisition_id"
                         invisible="not gocardless_requisition_id"
                         groups="base.group_no_one"


### PR DESCRIPTION
On #689, the date selection was flipped arguing that the transactions are discarded for a date interval out the other date. I have checked that when requesting transactions over a period, GoCardless returns the transactions based on both dates, so it's not a problem that the transaction is discarded in one round, because in the other it will appear, so we can still use "bookingDate".

The problem can be if the booking date is previous to the value date, and the transaction arrives to the bank later. You'll lost it depending on several factors: the download interval, if the transaction is near the interval change.

Let's be conservative, keeping the current value, but allowing to select the other date value.

@Tecnativa TT57550