### PR TITLE
[IMP] account_statement_import_camt: add a journal option to ignore transaction details

### DIFF
--- a/account_statement_import_camt/__manifest__.py
+++ b/account_statement_import_camt/__manifest__.py
@@ -8,5 +8,5 @@
     "website": "https://github.com/OCA/bank-statement-import",
     "category": "Banking addons",
     "depends": ["account_statement_import_file"],
-    "data": ["views/account_bank_statement_import.xml"],
+    "data": ["views/account_bank_statement_import.xml", "views/account_journal.xml"],
 }

--- a/account_statement_import_camt/models/account_journal.py
+++ b/account_statement_import_camt/models/account_journal.py
@@ -8,7 +8,7 @@ class AccountJournal(models.Model):
     _inherit = "account.journal"
 
     ignore_camt_transaction_details = fields.Boolean(
-        string="Ignore CAMT transaction details"
+        string="Ignore CAMT transaction details for negative amounts",
     )
 
     def _get_bank_statements_available_import_formats(self):

--- a/account_statement_import_camt/models/account_journal.py
+++ b/account_statement_import_camt/models/account_journal.py
@@ -1,11 +1,15 @@
 # Copyright 2019 ACSONE SA/NV <thomas.binsfeld@acsone.eu>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, models
+from odoo import _, fields, models
 
 
 class AccountJournal(models.Model):
     _inherit = "account.journal"
+
+    ignore_camt_transaction_details = fields.Boolean(
+        string="Ignore CAMT transaction details"
+    )
 
     def _get_bank_statements_available_import_formats(self):
         res = super()._get_bank_statements_available_import_formats()

--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -292,6 +292,15 @@ class AccountStatementImportCamtParser(models.AbstractModel):
             "ref",
         )
 
+        if "journal_id" in self.env.context:
+            journal = self.env["account.journal"].browse(
+                self.env.context.get("journal_id")
+            )
+            if journal.ignore_camt_transaction_details:
+                transaction["narration"] = transaction["narration"] or None
+                yield transaction
+                return
+
         # enrich the notes with some more infos when they are available
         self.add_value_from_node(
             ns,
@@ -332,7 +341,6 @@ class AccountStatementImportCamtParser(models.AbstractModel):
         transaction["transaction_type"] = (
             "-".join(transaction["transaction_type"].values()) or ""
         )
-
         details_nodes = node.xpath("./ns:NtryDtls/ns:TxDtls", namespaces={"ns": ns})
         if len(details_nodes) == 0:
             self.generate_narration(transaction)

--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -296,7 +296,7 @@ class AccountStatementImportCamtParser(models.AbstractModel):
             journal = self.env["account.journal"].browse(
                 self.env.context.get("journal_id")
             )
-            if journal.ignore_camt_transaction_details:
+            if journal.ignore_camt_transaction_details and amount < 0:
                 transaction["narration"] = transaction["narration"] or None
                 yield transaction
                 return

--- a/account_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_statement_import_camt/tests/test_import_bank_statement.py
@@ -147,7 +147,7 @@ class TestImport(TransactionCase):
                 "bank_id": cls.env.ref("base.res_bank_1").id,
             }
         )
-        cls.env["account.journal"].create(
+        cls.journal = cls.env["account.journal"].create(
             {
                 "name": "Bank Journal - (test camt)",
                 "code": "TBNKCAMT",
@@ -186,6 +186,25 @@ class TestImport(TransactionCase):
                     for line in statement_lines
                 )
             )
+
+    def test_statement_import_without_transaction_details(self):
+        """Test correct creation of single statement."""
+        self.journal.ignore_camt_transaction_details = True
+        testfile = file_path("account_statement_import_camt/tests/samples/test-camt053")
+        with open(testfile, "rb") as datafile:
+            camt_file = base64.b64encode(datafile.read())
+            self.env["account.statement.import"].create(
+                {
+                    "statement_filename": "test import",
+                    "statement_file": camt_file,
+                }
+            ).with_context(journal_id=self.journal.id).import_file_button()
+
+            bank_st_record = self.env["account.bank.statement"].search(
+                [("name", "=", "1234Test/1")], limit=1
+            )
+            statement_lines = bank_st_record.line_ids
+            self.assertEqual(len(statement_lines), 3)
 
     def test_zip_import(self):
         """Test import of multiple statements from zip file."""

--- a/account_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_statement_import_camt/tests/test_import_bank_statement.py
@@ -186,6 +186,8 @@ class TestImport(TransactionCase):
                     for line in statement_lines
                 )
             )
+            for line in statement_lines:
+                self.assertIsNotNone(line.partner_id)
 
     def test_statement_import_without_transaction_details(self):
         """Test correct creation of single statement."""
@@ -205,6 +207,11 @@ class TestImport(TransactionCase):
             )
             statement_lines = bank_st_record.line_ids
             self.assertEqual(len(statement_lines), 3)
+            for line in statement_lines:
+                if line.amount < 0:
+                    self.assertFalse(line.partner_id)
+                else:
+                    self.assertIsNotNone(line.partner_id)
 
     def test_zip_import(self):
         """Test import of multiple statements from zip file."""

--- a/account_statement_import_camt/views/account_journal.xml
+++ b/account_statement_import_camt/views/account_journal.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_account_journal_form" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='currency_id']" position="after">
+                <field name="ignore_camt_transaction_details" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When importing bank statements, all payment return transactions are imported individually.
To improve the reconciliation performance, it's better to have an option to group all payment return in a one transaction.

Migration of #263 