### PR TITLE
[IMP] account_statement_import_online: Running schedule should not trigger redundant `write` on journal and provider

### DIFF
--- a/account_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_statement_import_online/models/online_bank_statement_provider.py
@@ -122,7 +122,10 @@ class OnlineBankStatementProvider(models.Model):
     def write(self, vals):
         """Set provider_id on journal after creation."""
         result = super().write(vals)
-        self._update_journals()
+
+        if "journal_id" in vals or "service" in vals:
+            self._update_journals()
+
         return result
 
     def _update_journals(self):
@@ -520,9 +523,14 @@ class OnlineBankStatementProvider(models.Model):
         delta = self._get_next_run_period()
         now = datetime.now()
         next_run = self.next_run + delta
-        while next_run < now:
-            self.next_run = next_run
-            next_run = self.next_run + delta
+
+        if next_run < now:
+            current = next_run
+            while next_run < now:
+                current = next_run
+                next_run += delta
+
+            self.next_run = current
 
     def _obtain_statement_data(self, date_since, date_until):
         """Hook for extension"""

--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -100,6 +100,9 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
         self._getExpectedStatements(0)
         self.provider.with_context(step={"hours": 8})._scheduled_pull()
         self._getExpectedStatements(1)
+        self.assertEqual(
+            self.provider.next_run, self.now + self.provider._get_next_run_period()
+        )
 
     def test_pull_skip_duplicates_by_unique_import_id(self):
         self.provider.statement_creation_mode = "weekly"


### PR DESCRIPTION
Running schedule should not trigger redundant `write` on journal and provider