### PR TITLE
[18.0][FIX] account_statement_import_online_paypal: required changed to python expression 

### DIFF
--- a/account_statement_import_online_paypal/views/online_bank_statement_provider.xml
+++ b/account_statement_import_online_paypal/views/online_bank_statement_provider.xml
@@ -28,13 +28,13 @@
                             name="username"
                             string="Client ID"
                             password="True"
-                            required="'service', '=', 'paypal'"
+                            required="service == 'paypal'"
                         />
                         <field
                             name="password"
                             string="Secret"
                             password="True"
-                            required="'service', '=', 'paypal'"
+                            required="service == 'paypal'"
                         />
                     </group>
                 </group>


### PR DESCRIPTION
Wrong evaluation of required is affecting other services as it making those two fields required. 
#840 
@juancarlosonate-tecnativa @pedrobaeza 