### PR TITLE
[16.0][IMP] account_statement_import_camt: support datetime (DtTm) as booking date

### DIFF
--- a/account_statement_import_camt/models/parser.py
+++ b/account_statement_import_camt/models/parser.py
@@ -269,7 +269,9 @@ class CamtParser(models.AbstractModel):
             "narration": {},
             "transaction_type": {},
         }  # fallback defaults
-        self.add_value_from_node(ns, node, "./ns:BookgDt/ns:Dt", transaction, "date")
+        self.add_value_from_node(
+            ns, node, "./ns:BookgDt/ns:Dt | ./ns:BookgDt/ns:DtTm", transaction, "date"
+        )
         amount = self.parse_amount(ns, node)
         if amount != 0.0:
             transaction["amount"] = amount


### PR DESCRIPTION
Certain institutions (wise.com) use DtTm instead of Dt for transaction date, this fix supports either original Dt or DtTm