### PR TITLE
[17.0][FIX] account_statement_import_online_stripe: store valid json in raw_data.

### DIFF
--- a/account_statement_import_online_stripe/models/online_bank_statement_provider_stripe.py
+++ b/account_statement_import_online_stripe/models/online_bank_statement_provider_stripe.py
@@ -77,7 +77,7 @@ class OnlineBankStatementProviderStripe(models.Model):
                     "amount": float(tx["amount"]) / (10**currency.decimal_places),
                     "date": datetime.fromtimestamp(tx["created"]),
                     "unique_import_id": tx["id"],
-                    "raw_data": tx,
+                    "raw_data": json.dumps(tx),
                 }
             )
             if tx.get("fee"):
@@ -89,7 +89,7 @@ class OnlineBankStatementProviderStripe(models.Model):
                         "amount": float(-tx["fee"]) / (10**currency.decimal_places),
                         "date": datetime.fromtimestamp(tx["created"]),
                         "unique_import_id": tx["id"] + "_fee",
-                        "raw_data": tx,
+                        "raw_data": json.dumps(tx),
                     }
                 )
         return lines, {}


### PR DESCRIPTION
Storing `tx` directly means `raw_data` would end up containing the stringified python dict, which
is not actually JSON and is harder to parse.

backport of #846 to 17.0