### PR TITLE
[18.0][FIX] account_statement_import_online: fix excessive writes

### DIFF
--- a/account_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_statement_import_online/models/online_bank_statement_provider.py
@@ -122,7 +122,8 @@ class OnlineBankStatementProvider(models.Model):
     def write(self, vals):
         """Set provider_id on journal after creation."""
         result = super().write(vals)
-        self._update_journals()
+        if "journal_id" in vals or "service" in vals:
+            self._update_journals()
         return result
 
     def _update_journals(self):
@@ -524,10 +525,12 @@ class OnlineBankStatementProvider(models.Model):
         self.ensure_one()
         delta = self._get_next_run_period()
         now = datetime.now()
+        target_run = self.next_run
         next_run = self.next_run + delta
         while next_run < now:
-            self.next_run = next_run
-            next_run = self.next_run + delta
+            target_run = next_run
+            next_run = target_run + delta
+        self.next_run = target_run
 
     def _obtain_statement_data(self, date_since, date_until):
         """Hook for extension"""


### PR DESCRIPTION
* Don't update journals unless a relevant field is updated on the online configuration.
* Don't update next_run on the online configuration during every iteration of the interval. This could be many iterations if the configuration is not actually valid and the interval is very short. In the past, this also led to excessive logging which was adressed in https://github.com/OCA/bank-statement-import/pull/835.

A similar fix for 16 can be found in https://github.com/OCA/bank-statement-import/pull/832