### PR TITLE
[14.0][FIX] account_statement_import_online_wise: The "Generate Key" button…

### DIFF
--- a/account_statement_import_online_wise/views/online_bank_statement_provider.xml
+++ b/account_statement_import_online_wise/views/online_bank_statement_provider.xml
@@ -48,6 +48,7 @@
                         <div col="2" colspan="2">
                             <button
                                 name="button_transferwise_generate_key"
+                                string="Generate Key"
                                 title="Generate Key"
                                 type="object"
                                 class="oe_edit_only"


### PR DESCRIPTION
[FIX] account_statement_import_online_wise: The "Generate Key" button is always invisible without attribute `string`