### PR TITLE
[FIX] account_statement_import_sheet_file: Handle integer values in column concatenation

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -201,7 +201,12 @@ class AccountStatementImportSheetParser(models.TransientModel):
                     content_l.append(values[index])
         if all(isinstance(content, str) for content in content_l):
             return " ".join(content_l)
-        return content_l[0]
+        elif any(isinstance(content, int) for content in content_l):
+            # Convert all content to string and join when we have integers
+            return " ".join(str(content) for content in content_l)
+        else:
+            # Fallback to first content for other mixed types
+            return content_l[0]
 
     def _parse_rows(self, mapping, currency_code, data, columns):  # noqa: C901
         csv_or_xlsx, data_file = data


### PR DESCRIPTION
When mapping multiple columns for concatenation (e.g., "Ref number,Concept"), the _get_values_from_column method would only join values if all were strings. If one column contained an integer (like reference numbers), it would return only the first value instead of concatenating both columns as expected.

This fix adds specific handling for cases where any content is an integer, converting all values to strings before joining, while preserving the original fallback behavior for other mixed data types.