### PR TITLE
[16.0][IMP] account_statement_import_sheet_file: auto transaction ID from row hash

### DIFF
--- a/account_statement_import_sheet_file/i18n/account_statement_import_sheet_file.pot
+++ b/account_statement_import_sheet_file/i18n/account_statement_import_sheet_file.pot
@@ -495,6 +495,11 @@ msgid "Unified Chinese (gb18030)"
 msgstr ""
 
 #. module: account_statement_import_sheet_file
+#: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_auto
+msgid "Automatic operation ID"
+msgstr ""
+
+#. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_column
 msgid "Unique transaction ID column"
 msgstr ""

--- a/account_statement_import_sheet_file/i18n/es.po
+++ b/account_statement_import_sheet_file/i18n/es.po
@@ -527,6 +527,11 @@ msgid "Unified Chinese (gb18030)"
 msgstr "Unified Chinese (gb18030)"
 
 #. module: account_statement_import_sheet_file
+#: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_auto
+msgid "Automatic operation ID"
+msgstr ""
+
+#. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_column
 msgid "Unique transaction ID column"
 msgstr "Columna de ID único de trasacción"

--- a/account_statement_import_sheet_file/i18n/es_AR.po
+++ b/account_statement_import_sheet_file/i18n/es_AR.po
@@ -539,6 +539,11 @@ msgid "Unified Chinese (gb18030)"
 msgstr "Chino Unificado (gb18030)"
 
 #. module: account_statement_import_sheet_file
+#: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_auto
+msgid "Automatic operation ID"
+msgstr ""
+
+#. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_column
 msgid "Unique transaction ID column"
 msgstr "Columna de ID único de transacción"

--- a/account_statement_import_sheet_file/i18n/it.po
+++ b/account_statement_import_sheet_file/i18n/it.po
@@ -527,6 +527,11 @@ msgid "Unified Chinese (gb18030)"
 msgstr "Cinese unificato (gb18030)"
 
 #. module: account_statement_import_sheet_file
+#: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_auto
+msgid "Automatic operation ID"
+msgstr "ID Operazione automatica"
+
+#. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_column
 msgid "Unique transaction ID column"
 msgstr "Colonna ID operazione univoca"

--- a/account_statement_import_sheet_file/i18n/nl.po
+++ b/account_statement_import_sheet_file/i18n/nl.po
@@ -505,6 +505,11 @@ msgid "Unified Chinese (gb18030)"
 msgstr "Unified Chinese (gb18030)"
 
 #. module: account_statement_import_sheet_file
+#: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_auto
+msgid "Automatic operation ID"
+msgstr ""
+
+#. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_column
 msgid "Unique transaction ID column"
 msgstr "Unieke transactie ID kolom"

--- a/account_statement_import_sheet_file/i18n/pt.po
+++ b/account_statement_import_sheet_file/i18n/pt.po
@@ -526,6 +526,11 @@ msgid "Unified Chinese (gb18030)"
 msgstr "Chinês Unificado (gb18030)"
 
 #. module: account_statement_import_sheet_file
+#: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_auto
+msgid "Automatic operation ID"
+msgstr ""
+
+#. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_column
 msgid "Unique transaction ID column"
 msgstr "Coluna ID de transação única"

--- a/account_statement_import_sheet_file/i18n/tr.po
+++ b/account_statement_import_sheet_file/i18n/tr.po
@@ -526,6 +526,11 @@ msgid "Unified Chinese (gb18030)"
 msgstr "Birleşik Çince (gb18030)"
 
 #. module: account_statement_import_sheet_file
+#: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_auto
+msgid "Automatic operation ID"
+msgstr ""
+
+#. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_column
 msgid "Unique transaction ID column"
 msgstr "Benzersiz İşlem ID Sütunu"

--- a/account_statement_import_sheet_file/i18n/zh_CN.po
+++ b/account_statement_import_sheet_file/i18n/zh_CN.po
@@ -505,6 +505,11 @@ msgid "Unified Chinese (gb18030)"
 msgstr ""
 
 #. module: account_statement_import_sheet_file
+#: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_auto
+msgid "Automatic operation ID"
+msgstr ""
+
+#. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__transaction_id_column
 msgid "Unique transaction ID column"
 msgstr "唯一交易ID列名"

--- a/account_statement_import_sheet_file/models/account_journal.py
+++ b/account_statement_import_sheet_file/models/account_journal.py
@@ -10,7 +10,6 @@ class AccountJournal(models.Model):
 
     default_sheet_mapping_id = fields.Many2one(
         comodel_name="account.statement.import.sheet.mapping",
-        string="Default Sheet Mapping",
     )
 
     def _get_bank_statements_available_import_formats(self):

--- a/account_statement_import_sheet_file/models/account_journal.py
+++ b/account_statement_import_sheet_file/models/account_journal.py
@@ -10,6 +10,7 @@ class AccountJournal(models.Model):
 
     default_sheet_mapping_id = fields.Many2one(
         comodel_name="account.statement.import.sheet.mapping",
+        string="Default Sheet Mapping",
     )
 
     def _get_bank_statements_available_import_formats(self):

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
@@ -67,6 +67,9 @@ class AccountStatementImportSheetMapping(models.Model):
         "instead of the column name, considering that the first column is 0",
     )
     timestamp_column = fields.Char(required=True)
+    transaction_id_auto = fields.Boolean(
+        string="Automatic operation ID",
+    )
     currency_column = fields.Char(
         help=(
             "In case statement is multi-currency, column to get currency of "

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -2,6 +2,7 @@
 # Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import hashlib
 import itertools
 import logging
 import math
@@ -37,6 +38,20 @@ except ImportError:
 class AccountStatementImportSheetParser(models.TransientModel):
     _name = "account.statement.import.sheet.parser"
     _description = "Bank Statement Import Sheet Parser"
+
+    def _hash_row_values(self, values):
+        normalized_values = []
+        for value in values:
+            if value is None:
+                normalized_values.append("")
+            elif isinstance(value, datetime):
+                normalized_values.append(value.isoformat())
+            elif isinstance(value, float):
+                normalized_values.append(repr(value))
+            else:
+                normalized_values.append(str(value))
+        row_payload = "\x1f".join(normalized_values)
+        return hashlib.sha256(row_payload.encode("utf-8")).hexdigest()
 
     @api.model
     def parse_header(self, csv_or_xlsx, mapping):
@@ -285,11 +300,13 @@ class AccountStatementImportSheetParser(models.TransientModel):
                 if columns["debit_credit_column"]
                 else None
             )
-            transaction_id = (
-                self._get_values_from_column(values, columns, "transaction_id_column")
-                if columns["transaction_id_column"]
-                else None
-            )
+            transaction_id = None
+            if mapping.transaction_id_auto:
+                transaction_id = self._hash_row_values(values)
+            elif columns["transaction_id_column"]:
+                transaction_id = self._get_values_from_column(
+                    values, columns, "transaction_id_column"
+                )
             description = (
                 self._get_values_from_column(values, columns, "description_column")
                 if columns["description_column"]

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -2,6 +2,7 @@
 # Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import hashlib
 import itertools
 import logging
 import math
@@ -37,6 +38,20 @@ except ImportError:
 class AccountStatementImportSheetParser(models.TransientModel):
     _name = "account.statement.import.sheet.parser"
     _description = "Bank Statement Import Sheet Parser"
+
+    def _hash_row_values(self, values):
+        normalized_values = []
+        for value in values:
+            if value is None:
+                normalized_values.append("")
+            elif isinstance(value, datetime):
+                normalized_values.append(value.isoformat())
+            elif isinstance(value, float):
+                normalized_values.append(repr(value))
+            else:
+                normalized_values.append(str(value))
+        row_payload = "\x1f".join(normalized_values)
+        return hashlib.sha256(row_payload.encode("utf-8")).hexdigest()
 
     @api.model
     def parse_header(self, csv_or_xlsx, mapping):
@@ -283,11 +298,13 @@ class AccountStatementImportSheetParser(models.TransientModel):
                 if columns["debit_credit_column"]
                 else None
             )
-            transaction_id = (
-                self._get_values_from_column(values, columns, "transaction_id_column")
-                if columns["transaction_id_column"]
-                else None
-            )
+            transaction_id = None
+            if mapping.transaction_id_auto:
+                transaction_id = self._hash_row_values(values)
+            elif columns["transaction_id_column"]:
+                transaction_id = self._get_values_from_column(
+                    values, columns, "transaction_id_column"
+                )
             description = (
                 self._get_values_from_column(values, columns, "description_column")
                 if columns["description_column"]

--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -2,7 +2,7 @@
 # Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from decimal import Decimal
 from os import path
 from unittest.mock import Mock
@@ -73,11 +73,6 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             return b64encode(data)
 
     def test_import_csv_file(self):
-        statement_map = self.sample_statement_map.copy(
-            {
-                "transaction_id_auto": True,
-            }
-        )
         journal = self.AccountJournal.create(
             {
                 "name": "Bank",
@@ -92,7 +87,7 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             {
                 "statement_filename": "fixtures/sample_statement_en.csv",
                 "statement_file": data,
-                "sheet_mapping_id": statement_map.id,
+                "sheet_mapping_id": self.sample_statement_map.id,
             }
         )
         wizard.with_context(
@@ -101,9 +96,6 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
         statement = self.AccountBankStatement.search([("journal_id", "=", journal.id)])
         self.assertEqual(len(statement), 1)
         self.assertEqual(len(statement.line_ids), 2)
-        unique_import_ids = statement.line_ids.mapped("unique_import_id")
-        self.assertTrue(all(unique_import_ids))
-        self.assertEqual(len(set(unique_import_ids)), 2)
 
     def test_hash_row_values(self):
         values = [None, self.now, 12.34, "Payment"]
@@ -114,6 +106,20 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             row_hash,
             self.parser._hash_row_values([None, self.now, 12.34, "Other payment"]),
         )
+
+    def test_transaction_id_auto(self):
+        statement_map = self.sample_statement_map.copy(
+            {
+                "transaction_id_auto": True,
+            }
+        )
+        data = b64decode(self._data_file("fixtures/sample_statement_en.csv", "utf-8"))
+
+        lines = self.parser._parse_lines(statement_map, data, self.currency_usd.name)
+
+        transaction_ids = [line.get("transaction_id") for line in lines]
+        self.assertTrue(all(transaction_ids))
+        self.assertEqual(len(set(transaction_ids)), 2)
 
     def test_import_empty_csv_file(self):
         journal = self.AccountJournal.create(

--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -73,6 +73,11 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             return b64encode(data)
 
     def test_import_csv_file(self):
+        statement_map = self.sample_statement_map.copy(
+            {
+                "transaction_id_auto": True,
+            }
+        )
         journal = self.AccountJournal.create(
             {
                 "name": "Bank",
@@ -87,7 +92,7 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             {
                 "statement_filename": "fixtures/sample_statement_en.csv",
                 "statement_file": data,
-                "sheet_mapping_id": self.sample_statement_map.id,
+                "sheet_mapping_id": statement_map.id,
             }
         )
         wizard.with_context(
@@ -96,6 +101,19 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
         statement = self.AccountBankStatement.search([("journal_id", "=", journal.id)])
         self.assertEqual(len(statement), 1)
         self.assertEqual(len(statement.line_ids), 2)
+        unique_import_ids = statement.line_ids.mapped("unique_import_id")
+        self.assertTrue(all(unique_import_ids))
+        self.assertEqual(len(set(unique_import_ids)), 2)
+
+    def test_hash_row_values(self):
+        values = [None, self.now, 12.34, "Payment"]
+        row_hash = self.parser._hash_row_values(values)
+
+        self.assertEqual(row_hash, self.parser._hash_row_values(values))
+        self.assertNotEqual(
+            row_hash,
+            self.parser._hash_row_values([None, self.now, 12.34, "Other payment"]),
+        )
 
     def test_import_empty_csv_file(self):
         journal = self.AccountJournal.create(

--- a/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
+++ b/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
@@ -86,6 +86,7 @@
                         </group>
                         <group>
                             <field name="timestamp_column" />
+                            <field name="transaction_id_auto" />
                             <field name="currency_column" />
                             <field name="amount_type" />
                             <field
@@ -121,7 +122,10 @@
                                     'invisible': [('amount_type', '!=', 'absolute_value')],
                                     }"
                             />
-                            <field name="transaction_id_column" />
+                            <field
+                                name="transaction_id_column"
+                                attrs="{'invisible': [('transaction_id_auto', '=', True)]}"
+                            />
                             <field name="description_column" />
                             <field name="notes_column" />
                             <field name="reference_column" />


### PR DESCRIPTION
## Description

This PR adds an option to automatically generate the transaction ID during sheet import.
When enabled, the ID is computed by hashing the row values, preventing duplicates when no explicit ID column is available.

## Changes

1) Added Automatic operation ID option in the mapping; Hide transaction_id_column when the option is enabled.
2) Generate the ID via row-value hash.
3) Updated strings and translations.