### PR TITLE
[FIX] account_statement_import_online: timezone handling

### DIFF
--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -312,6 +312,74 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
         self.assertEqual(lines[2].date, date(2020, 4, 18))
         self.assertEqual(lines[3].date, date(2020, 4, 18))
 
+    def test_daily_statement_window_uses_provider_timezone(self):
+        """
+        Daily pull should pull data for the day according to the provider timezone, not according to UTC.
+        Pulling data for 15th of November with provider timezone being Europe/Vienna,
+        should pull data from 23:00 on 14th of November to 23:00 on 15th of November in UTC terms,
+        as this corresponds to 00:00 on 15th of November to 00:00 on 16th of November in provider local time.
+        """
+        self.provider.statement_creation_mode = "daily"
+        self.provider.tz = "Europe/Vienna"
+        with mock.patch(mock_obtain_statement_data, return_value=([], {})) as mock_data:
+            self.provider._pull(
+                datetime(2025, 11, 15, 7, 0),
+                datetime(2025, 11, 15, 7, 0),
+            )
+        mock_data.assert_called_once()
+        self.assertEqual(
+            mock_data.call_args.args,
+            (datetime(2025, 11, 14, 23, 0), datetime(2025, 11, 15, 23, 0)),
+        )
+
+    def test_statement_name_uses_provider_local_date(self):
+        """
+        See above test. The name of the statement should also be based on the provider local date, not on UTC date.
+        """
+        self.provider.tz = "Europe/Vienna"
+        self.assertEqual(
+            self.provider.make_statement_name(datetime(2025, 11, 14, 23, 0)),
+            "BANK/2025-11-15",
+        )
+
+    def test_daily_statement_window_handles_dst_start(self):
+        """
+        On the DST start day in Europe/Vienna, the local day is 23 hours long.
+        Pulling data for 30th of March 2025 should therefore use the UTC window
+        2025-03-29 23:00:00 to 2025-03-30 22:00:00.
+        """
+        self.provider.statement_creation_mode = "daily"
+        self.provider.tz = "Europe/Vienna"
+        with mock.patch(mock_obtain_statement_data, return_value=([], {})) as mock_data:
+            self.provider._pull(
+                datetime(2025, 3, 30, 6, 0),
+                datetime(2025, 3, 30, 6, 0),
+            )
+        mock_data.assert_called_once()
+        self.assertEqual(
+            mock_data.call_args.args,
+            (datetime(2025, 3, 29, 23, 0), datetime(2025, 3, 30, 22, 0)),
+        )
+
+    def test_daily_statement_window_handles_dst_end(self):
+        """
+        On the DST end day in Europe/Vienna, the local day is 25 hours long.
+        Pulling data for 26th of October 2025 should therefore use the UTC
+        window 2025-10-25 22:00:00 to 2025-10-26 23:00:00.
+        """
+        self.provider.statement_creation_mode = "daily"
+        self.provider.tz = "Europe/Vienna"
+        with mock.patch(mock_obtain_statement_data, return_value=([], {})) as mock_data:
+            self.provider._pull(
+                datetime(2025, 10, 26, 7, 0),
+                datetime(2025, 10, 26, 7, 0),
+            )
+        mock_data.assert_called_once()
+        self.assertEqual(
+            mock_data.call_args.args,
+            (datetime(2025, 10, 25, 22, 0), datetime(2025, 10, 26, 23, 0)),
+        )
+
     def test_other_tz_to_utc(self):
         """Test the situation where we are tot the west of the provider.
 


### PR DESCRIPTION
In https://github.com/OCA/bank-statement-import/pull/418 a timezone-related issue was reported for daily online statement imports. That PR was eventually closed due to inactivity, but the underlying behavior is still present.

This PR intentionally adds **regression tests only** to make the current behavior explicit and to restart discussion on the expected behavior and migration strategy.

## What this PR adds

Regression tests in `account_statement_import_online` for provider timezone handling in daily mode:

- daily window should be based on provider local day (Europe/Vienna), not UTC midnight
- statement name should follow provider local date
- DST start transition (23-hour local day) boundary handling
- DST end transition (25-hour local day) boundary handling

## Why tests only

As discussed in #418, changing this behavior can be a breaking change for existing users (statement boundaries, statement names, potential downstream reconciliation/reporting expectations).

Before implementing a fix, it would be good to align on:

- expected canonical behavior (strict provider-local day boundaries vs current UTC day boundaries)
- migration needs for existing databases

## Current status

With current 19.0 code, these new regression tests fail, demonstrating the issue reproducibly:

- `test_daily_statement_window_uses_provider_timezone`
- `test_statement_name_uses_provider_local_date`
- `test_daily_statement_window_handles_dst_start`
- `test_daily_statement_window_handles_dst_end`

In all cases, current behavior still uses UTC `00:00 -> 00:00` daily windows rather than provider-local day boundaries.

## Additional impact: statement attribution and line ordering

The timezone boundary issue is not only about transactions being fetched on the next run. It also affects how transactions are attributed and ordered.

When daily windows are interpreted in UTC instead of provider local time, boundary transactions are imported in the following pull. This means a “daily” statement (from a local-time perspective) can contain transactions from two local calendar days.

This also has side effects even when `create_statement` is disabled: `account.bank.statement.line` ordering is based on date/sequence/id (via `internal_index`). Many providers (for example PayPal) do not provide a meaningful sequence and use the default sequence value, so boundary transactions imported later are ordered by insertion/id instead of real transaction chronology. The result is visibly out-of-order lines, which is confusing for reconciliation and reporting.
