### PR TITLE
[18.0][IMP] account_statement_import_base: Ensure unique_import_id is set

### DIFF
--- a/account_statement_import_base/__manifest__.py
+++ b/account_statement_import_base/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Akretion France (http://www.akretion.com/)
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 
@@ -14,6 +15,7 @@
     "website": "https://github.com/OCA/bank-statement-import",
     "data": [
         "views/account_bank_statement_line.xml",
+        "views/account_journal.xml",
     ],
     "installable": True,
 }

--- a/account_statement_import_base/models/account_journal.py
+++ b/account_statement_import_base/models/account_journal.py
@@ -1,14 +1,22 @@
 # Copyright 2022 Akretion France (http://www.akretion.com/)
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 from odoo.addons.base.models.res_bank import sanitize_account_number
 
 
 class AccountJournal(models.Model):
     _inherit = "account.journal"
+
+    ensure_unique_import_id = fields.Boolean(
+        help="Ensures that a unique_import_id is set"
+        "on a bank statement lines when importing it via bank statement import"
+        "If no unique identifier was provided, the value is created from the "
+        "account number, date, payment reference and amount."
+    )
 
     def _statement_line_import_speeddict(self):
         """This method is designed to be inherited by reconciliation modules.
@@ -53,11 +61,27 @@ class AccountJournal(models.Model):
                     speeddict["account_number"][st_line_vals["account_number"]]
                 )
 
+    @api.model
+    def _get_unique_identifier_keys(self):
+        return ["account_number", "date", "payment_ref", "amount"]
+
+    def _generate_statement_line_unique_import_id(self, st_line_vals):
+        values = []
+        for key in self._get_unique_identifier_keys():
+            value = st_line_vals.get(key)
+            if value:
+                values.append(str(value))
+        return "-".join(values)
+
     def _statement_line_import_update_unique_import_id(
         self, st_line_vals, account_number
     ):
         self.ensure_one()
         unique_import_id = st_line_vals.get("unique_import_id")
+        if not unique_import_id and self.ensure_unique_import_id:
+            unique_import_id = self._generate_statement_line_unique_import_id(
+                st_line_vals
+            )
         if unique_import_id:
             sanitized_acc_number = self._sanitize_bank_account_number(account_number)
             st_line_vals["unique_import_id"] = (

--- a/account_statement_import_base/readme/CONTRIBUTORS.md
+++ b/account_statement_import_base/readme/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 - Alexis de Lattre \<<alexis.delattre@akretion.com>\>
+- Michael Tietz (MT Software) \<<mtietz@mt-software.de>\>
 
 - Trobz \<<https://www.trobz.com/>\>
   - Do Anh Duy \<<duyda@trobz.com>\>

--- a/account_statement_import_base/tests/__init__.py
+++ b/account_statement_import_base/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_generate_unique_import_id

--- a/account_statement_import_base/tests/test_generate_unique_import_id.py
+++ b/account_statement_import_base/tests/test_generate_unique_import_id.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import odoo.tests.common as common
+
+
+class TestGenerateUniqueImportId(common.TransactionCase):
+    def test_unique_import_id(self):
+        journal = self.env["account.journal"].create(
+            {
+                "name": "Test Journal",
+                "code": "AST-1",
+                "type": "bank",
+            }
+        )
+        st_line_vals = {
+            "account_number": "1234",
+            "date": "2026-03-13",
+            "payment_ref": "Payment",
+            "amount": 100.0,
+        }
+        account_number = "11111"
+        unique_import_id_prefix = f"{account_number}-{journal.id}"
+        journal._statement_line_import_update_unique_import_id(
+            st_line_vals, account_number
+        )
+        self.assertFalse(st_line_vals.get("unique_imort_id"))
+        st_line_vals["unique_import_id"] = "unique_import_id"
+        journal._statement_line_import_update_unique_import_id(
+            st_line_vals, account_number
+        )
+        self.assertEqual(
+            st_line_vals.get("unique_import_id"),
+            f"{unique_import_id_prefix}-unique_import_id",
+        )
+        st_line_vals.pop("unique_import_id")
+        journal.ensure_unique_import_id = True
+        journal._statement_line_import_update_unique_import_id(
+            st_line_vals, account_number
+        )
+        self.assertEqual(
+            st_line_vals.get("unique_import_id"),
+            f"{unique_import_id_prefix}-1234-2026-03-13-Payment-100.0",
+        )
+        st_line_vals.pop("date")
+        st_line_vals.pop("unique_import_id")
+        journal._statement_line_import_update_unique_import_id(
+            st_line_vals, account_number
+        )
+        self.assertEqual(
+            st_line_vals.get("unique_import_id"),
+            f"{unique_import_id_prefix}-1234-Payment-100.0",
+        )
+        st_line_vals["unique_import_id"] = "unique_import_id"
+        journal._statement_line_import_update_unique_import_id(
+            st_line_vals, account_number
+        )
+        self.assertEqual(
+            st_line_vals.get("unique_import_id"),
+            f"{unique_import_id_prefix}-unique_import_id",
+        )

--- a/account_statement_import_base/views/account_journal.xml
+++ b/account_statement_import_base/views/account_journal.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<!--
+  Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
+  Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
+-->
+<odoo>
+    <record id="account_journal_from_view" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="arch" type="xml">
+            <field name="autocheck_on_post" position="after">
+                <field name="ensure_unique_import_id" invisible="type != 'bank'" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Right now the unique_import_id is not set by default. 
This PR allows to configure a journal to generate a unique id if not set. 