### PR TITLE
[18.0][IMP] account_statement_import_file: Aggregated error reporting and API refinement

### DIFF
--- a/account_statement_import_file/models/account_journal.py
+++ b/account_statement_import_file/models/account_journal.py
@@ -42,5 +42,5 @@ class AccountJournal(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id(
             "account_statement_import_file.account_statement_import_action"
         )
-        action["context"] = {"journal_id": self.id}
+        action["context"] = {"default_journal_id": self.id, "journal_id": self.id}
         return action

--- a/account_statement_import_file/tests/test_account_statement_import_file.py
+++ b/account_statement_import_file/tests/test_account_statement_import_file.py
@@ -43,7 +43,12 @@ class TestAccountStatementImportFile(common.TransactionCase):
         cls.import_wizard = (
             cls.env["account.statement.import"]
             .with_context(journal_id=cls.journal_1.id)
-            .create({"statement_file": file, "statement_filename": "Test"})
+            .create(
+                {
+                    "statement_file": file,
+                    "statement_filename": "Test",
+                }
+            )
         )
 
     def test_complete_stmts_vals(self):

--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -4,7 +4,7 @@
 import base64
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from odoo.addons.base.models.res_bank import sanitize_account_number
@@ -21,6 +21,7 @@ class AccountStatementImport(models.TransientModel):
         help="Download bank statement files from your bank and upload them here.",
     )
     statement_filename = fields.Char()
+    journal_id = fields.Many2one("account.journal", string="Journal")
 
     def _import_file(self):
         self.ensure_one()
@@ -28,6 +29,9 @@ class AccountStatementImport(models.TransientModel):
             "statement_ids": [],
             "notifications": [],  # list of text messages
         }
+        self = self.with_context(
+            journal_id=self.journal_id.id or self.env.context.get("journal_id")
+        )
         logger.info("Start to import bank statement file %s", self.statement_filename)
         file_data = base64.b64decode(self.statement_file)
         self.import_single_file(file_data, result)
@@ -50,6 +54,8 @@ class AccountStatementImport(models.TransientModel):
     def import_file_button(self):
         """Process the file chosen in the wizard, create bank statement(s)
         and return an action."""
+        if self.env.context.get("from_import_button") and not self.journal_id:
+            raise UserError(_("A journal must be selected before importing."))
         result = self._import_file()
         action = self.env["ir.actions.actions"]._for_xml_id(
             "account.action_bank_statement_tree"

--- a/account_statement_import_file/wizard/account_statement_import_view.xml
+++ b/account_statement_import_file/wizard/account_statement_import_view.xml
@@ -14,6 +14,13 @@
                 <p>Supported formats:</p>
                 <ul id="statement_format">
                     <!-- <li>xxx format</li> is added by format-specific modules -->
+                    <li>Journal:
+                        <field
+                        name="journal_id"
+                        domain="[('type', '=', 'bank')]"
+                        readonly="context.get('journal_id')"
+                    />
+                    </li>
                 </ul>
                 <field name="statement_file" filename="statement_filename" />
                 <field name="statement_filename" invisible="1" />
@@ -23,6 +30,7 @@
                         string="Import and View"
                         type="object"
                         class="btn-primary"
+                        context="{'from_import_button': True}"
                     />
 
                     <button string="Cancel" class="btn-default" special="cancel" />


### PR DESCRIPTION
This module enhances the bank statement import process by introducing a **Journal selection field** in the import wizard.

## Features
- Adds a **Journal** (`journal_id`) field to the bank statement import wizard.
- Allows users to explicitly select the target journal while importing bank statements from files.

### From Accounting Dashboard
- When importing from a specific journal (via the dashboard), the **Journal field is automatically populated**.
- The field is set to **read-only**, ensuring consistency and preventing accidental changes.

### From Import Statement Menu
- When accessing the import wizard from the generic **Import Statement menu**, users are required to **manually select the Journal**.
- This ensures correct journal assignment before processing the import.

## Benefits

- Ensures accurate journal mapping during bank statement import.
- Prevents incorrect journal selection when importing from the dashboard.
- Improves usability and control over the import process.