### PR TITLE
[18.0][FIX] account_statement_import_online: fix flaky midnight-UTC test

### DIFF
--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -38,7 +38,10 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
 
         cls.loader.update_registry((OnlineBankStatementProviderDummy,))
 
-        cls.now = fields.Datetime.now()
+        # Use a fixed time at noon UTC to avoid flaky failures when CI runs
+        # near midnight (subtracting 1 hour would cross the day boundary,
+        # creating 2 daily statement periods instead of 1).
+        cls.now = fields.Datetime.now().replace(hour=12, minute=0, second=0)
         cls.AccountAccount = cls.env["account.account"]
         cls.AccountJournal = cls.env["account.journal"]
         cls.OnlineBankStatementProvider = cls.env["online.bank.statement.provider"]


### PR DESCRIPTION
## Summary

- Pin `cls.now` to noon UTC in test setup to prevent flaky failures when CI runs near midnight

## Problem

Three tests (`test_pull_scheduled`, `test_wizard`, `test_wizard_on_journal`) use `self.now - relativedelta(hours=1)` as `date_since`. When CI executes between 00:00-00:59 UTC, subtracting 1 hour crosses the midnight boundary into the previous calendar day. With `statement_creation_mode = "daily"`, this creates 2 daily statement periods instead of the expected 1, causing:

```
AssertionError: 2 != 1
```

This was observed in CI run https://github.com/OCA/bank-statement-import/actions/runs/23392484656 (executed at 00:55 UTC on 2026-03-22).

## Fix

Replace `fields.Datetime.now()` with `fields.Datetime.now().replace(hour=12)` so hour-level subtractions never cross a day boundary. No test depends on the actual wall-clock time — all use relative offsets from `cls.now`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
AI-assisted (Claude Code); every change reviewed, tested, and owned by the author.