### PR TITLE
[18.0][IMP] account_statement_import_base: expose unique_import_id in list view

### DIFF
--- a/account_statement_import_base/views/account_bank_statement_line.xml
+++ b/account_statement_import_base/views/account_bank_statement_line.xml
@@ -22,4 +22,18 @@
             </group>
         </field>
     </record>
+
+    <record id="account_bank_statement_line_tree" model="ir.ui.view">
+        <field name="name">account.bank.statement.line.tree</field>
+        <field name="model">account.bank.statement.line</field>
+        <field
+            name="inherit_id"
+            ref="account_statement_base.account_bank_statement_line_tree"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='sequence']" position="after">
+                <field name="unique_import_id" readonly="1" optional="hide" />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
## Improvement
This PR enhances the usability of the `account_statement_import_base` module by making the `unique_import_id` field available in the bank statement line tree view. 
This field is crucial for troubleshooting and identifying specific transactions from the original imported source files, especially when dealing with duplicates or verification.
### Changes:
- **Views**: Modified `views/account_bank_statement_line.xml` to inherit `account_statement_base.account_bank_statement_line_tree` and added the `unique_import_id` field with `optional="hide"`.