### PR TITLE
[18][account_statement_import_file_reconcile_oca][FIX] Make active_ids and active_model consistent with active_id

### DIFF
--- a/account_statement_import_file_reconcile_oca/wizards/account_statement_import.py
+++ b/account_statement_import_file_reconcile_oca/wizards/account_statement_import.py
@@ -18,6 +18,8 @@ class AccountStatementImport(models.TransientModel):
         action["context"] = {
             "default_journal_id": self._context.get("journal_id"),
             "active_id": self._context.get("journal_id"),
+            "active_ids": [self._context.get("journal_id")],
+            "active_model": "account.journal",
             "search_default_not_reconciled": True,
             "view_ref": "account_reconcile_oca.bank_statement_line_form_reconcile_view",
         }


### PR DESCRIPTION
With the current code, in the bank statement reconciliation view, the active_id is the one of the journal, while active_ids is the id of the import wizard and active_model is the also from the wizard (`account.statement.import`)
I don't think there is a bug because of it, but it is totally inconsistent and needs to be fixed.