### PR TITLE
[18][account_statement_import_file][FIX] force active model and id toward journal

### DIFF
--- a/account_statement_import_file/wizard/account_statement_import.py
+++ b/account_statement_import_file/wizard/account_statement_import.py
@@ -6,6 +6,7 @@ import logging
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools.safe_eval import safe_eval
 
 from odoo.addons.base.models.res_bank import sanitize_account_number
 
@@ -56,6 +57,15 @@ class AccountStatementImport(models.TransientModel):
         )
         # there is no more bank statement form view in v16
         action["domain"] = [("id", "in", result["statement_ids"])]
+        ctx = safe_eval(action.get("context", "{}"))
+        ctx.update(
+            {
+                "active_id": self._context.get("journal_id"),
+                "active_ids": [self._context.get("journal_id")],
+                "active_model": "account.journal",
+            }
+        )
+        action["context"] = ctx
         if result["notifications"]:
             action_with_notif = {
                 "type": "ir.actions.client",


### PR DESCRIPTION
There is a bug making it impossible to reconcile a statement line when the reconciliation directly follow the import of the bank statement. (but with module `account_reconcile_oca` installed)

How to reproduce the issue : 
- Import a bank statement file using the button "import file and view" for the journal in the dashboard menu.
Odoo import and redirect you toward the created bank statement.
- Open the bank statement and click on the button "transactions" (`action_open_statement_lines`)  https://github.com/OCA/account-reconcile/blob/18.0/account_reconcile_oca/models/account_bank_statement.py#L23
- Odoo set the context key default_journal_id with the active key, it expects we come from a journal, which is not the case in case of file import, we comes from the wizard import.https://github.com/OCA/account-reconcile/blob/18.0/account_reconcile_oca/views/account_bank_statement_line.xml#L348

Then, if you try to reconcile adding an analytic distribution, Odoo will try to create an analytic line setting the id of the wizard in the journal_id, making errors foreign key errors...

So the fix consists on forcing the active key to the journal one in the context, same as in account_statement_import_file_reconcile_oca https://github.com/OCA/bank-statement-import/blob/18.0/account_statement_import_file_reconcile_oca/wizards/account_statement_import.py#L20