### PR TITLE
[18.0][FIX] account_statement_import_sheet_file: preserve file order for equal timestamps

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
@@ -98,6 +98,18 @@ class AccountStatementImportSheetMapping(models.Model):
     balance_column = fields.Char(
         help="Balance after transaction in journal's currency",
     )
+    statement_order = fields.Selection(
+        selection=[
+            ("asc", "Oldest first"),
+            ("desc", "Newest first"),
+        ],
+        default="asc",
+        required=True,
+        help=(
+            "Order of the statement file rows. This is used to preserve the "
+            "original file order when several transactions have the same timestamp."
+        ),
+    )
     original_currency_column = fields.Char(
         help=(
             "In case statement provides original currency for transactions "

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -3,7 +3,6 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-import itertools
 import logging
 import math
 import re
@@ -68,7 +67,7 @@ class AccountStatementImportSheetParser(models.TransientModel):
         if not lines:
             return currency_code, account_number, [{"transactions": []}]
 
-        lines = list(sorted(lines, key=lambda line: line["timestamp"]))
+        lines = self._sort_lines(mapping, lines)
         first_line = lines[0]
         last_line = lines[-1]
         data = {
@@ -90,14 +89,39 @@ class AccountStatementImportSheetParser(models.TransientModel):
                     "balance_end_real": balance_end,
                 }
             )
-        transactions = list(
-            itertools.chain.from_iterable(
-                map(lambda line: self._convert_line_to_transactions(line), lines)
-            )
-        )
+        transactions = []
+        total_lines = len(lines)
+
+        for index, line in enumerate(lines):
+            line_transactions = self._convert_line_to_transactions(line)
+
+            # Odoo uses sequence in reverse in internal_index:
+            # longest sequence = oldest line within the same day.
+            sequence = total_lines - index
+
+            for transaction in line_transactions:
+                transaction["sequence"] = sequence
+
+            transactions.extend(line_transactions)
+
         data.update({"transactions": transactions})
 
         return currency_code, account_number, [data]
+
+    @api.model
+    def _sort_lines(self, mapping, lines):
+        """Sort lines preserving file order for equal timestamps."""
+        for sequence, line in enumerate(lines):
+            line["_file_sequence"] = sequence
+        if mapping.statement_order == "desc":
+            return list(
+                sorted(
+                    lines, key=lambda line: (line["timestamp"], -line["_file_sequence"])
+                )
+            )
+        return list(
+            sorted(lines, key=lambda line: (line["timestamp"], line["_file_sequence"]))
+        )
 
     def _get_column_indexes(self, header, column_name, mapping):
         column_indexes = []

--- a/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
+++ b/account_statement_import_sheet_file/views/account_statement_import_sheet_mapping.xml
@@ -73,6 +73,7 @@
                         </group>
                         <group>
                             <field name="timestamp_column" />
+                            <field name="statement_order" />
                             <field name="currency_column" />
                             <field name="amount_type" />
                             <field


### PR DESCRIPTION
This fixes imports where multiple transactions share the same date/timestamp.

Current behavior sorts only by timestamp, which may reorder lines incorrectly when:

- the statement file contains only dates (no time column)
- multiple rows share the same timestamp
- files are exported newest-first

This may produce incorrect:

- starting balance
- running balance
- transaction ordering

This patch preserves original file order as a tie breaker while respecting the selected statement order.

Tested with Wise CSV exports.