### PR TITLE
[16.0] [IMP] account_statement_import_sheet_file: add a hook function

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
@@ -252,3 +252,6 @@ class AccountStatementImportSheetMapping(models.Model):
 
     def _get_column_delimiter_character(self):
         return self._decode_column_delimiter_character(self.delimiter)
+
+    def _skip_row(self, values, columns):
+        return False

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -236,6 +236,8 @@ class AccountStatementImportSheetParser(models.TransientModel):
                 if index >= footer_line:
                     continue
                 values = list(row)
+            if mapping._skip_row(values, columns):
+                continue
             if mapping.skip_empty_lines and not any(values):
                 continue
 


### PR DESCRIPTION
We add a hook function that helps filter the rows. In other modules or in your private modules, you can override this function to adapt it to the characteristics of your file.

Example:
If we have a statement import file with denied transactions, we can filter them out to skip them.