### PR TITLE
[19.0][FIX] ..import_camt: fix error when node is an empty element

### DIFF
--- a/account_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_statement_import_camt/tests/test_import_bank_statement.py
@@ -9,6 +9,8 @@ import tempfile
 from datetime import date
 from pathlib import Path
 
+from lxml import etree
+
 from odoo.tests.common import TransactionCase
 from odoo.tools.misc import file_path
 
@@ -94,6 +96,48 @@ class TestParser(TestParserCommon):
 
     def test_parse_no_ntry(self):
         self._do_parse_test("test-camt053-no-ntry", "golden-camt053-no-ntry.pydata")
+
+    def test_parse_empty_element(self):
+        DATA = """\
+        <?xml version="1.0" encoding="utf-8"?>
+        <Document
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02"
+        >
+            <BkToCstmrStmt>
+                <Stmt>
+                    <Ntry>
+                        <NtryDtls>
+                            <TxDtls>
+                                <RmtInf>
+                                    <Ustrd/>
+                                </RmtInf>
+                            </TxDtls>
+                        </NtryDtls>
+                    </Ntry>
+                </Stmt>
+            </BkToCstmrStmt>
+        </Document>
+        """
+        root = etree.fromstring(DATA, parser=etree.XMLParser(recover=True))
+        ns = root.tag[1 : root.tag.index("}")]
+        transaction = {}
+        details_nodes = root.xpath("//ns:NtryDtls/ns:TxDtls", namespaces={"ns": ns})
+        node = details_nodes[0]
+        self.parser.add_value_from_node(
+            ns,
+            node,
+            [
+                "./ns:RmtInf/ns:Ustrd|./ns:RtrInf/ns:AddtlInf",
+                "./ns:AddtlNtryInf",
+                "./ns:Refs/ns:InstrId",
+            ],
+            transaction,
+            "payment_ref",
+            join_str="\n",
+        )
+        self.assertNotIn("payment_ref", transaction)
 
 
 class TestImport(TransactionCase):

--- a/account_statement_import_camt/wizard/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/wizard/account_statement_import_camt_parser.py
@@ -50,7 +50,10 @@ class AccountStatementImportCamtParser(models.AbstractModel):
                 elif join_str is None:
                     attr_value = found_node[0].text
                 else:
-                    attr_value = join_str.join([x.text for x in found_node])
+                    # x.text can be None for empty element (example: <Ustrd />).
+                    attr_value = join_str.join([x.text for x in found_node if x.text])
+                if not attr_value:
+                    continue
                 obj[attr_name] = attr_value
                 break
 


### PR DESCRIPTION
Import would have an exception when encountering `<RmtInf><Ustrd /></RmtInf>`:

  File "/home/odooedprd19/odoo/auto/addons/account_statement_import_camt/wizard/account_statement_import_camt_parser.py", line 60, in parse_transaction_details
    self.add_value_from_node(
    ~~~~~~~~~~~~~~~~~~~~~~~~^
        ns,
        ^^^
    ...<8 lines>...
        join_str="\n",
        ^^^^^^^^^^^^^^
    )
    ^
  File "/home/odooedprd19/odoo/auto/addons/account_statement_import_camt/wizard/account_statement_import_camt_parser.py", line 53, in add_value_from_node
    attr_value = join_str.join([x.text for x in found_node])
TypeError: sequence item 0: expected str instance, NoneType found