### PR TITLE
UPD camt parser: filter empty text nodes and enhance transaction details

### DIFF
--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -50,7 +50,7 @@ class AccountStatementImportCamtParser(models.AbstractModel):
                 elif join_str is None:
                     attr_value = found_node[0].text
                 else:
-                    attr_value = join_str.join([x.text for x in found_node])
+                    attr_value = join_str.join([x.text for x in found_node if x.text])
                 obj[attr_name] = attr_value
                 break
 
@@ -289,6 +289,7 @@ class AccountStatementImportCamtParser(models.AbstractModel):
                 "./ns:NtryDtls/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Ref",
                 "./ns:NtryDtls/ns:Btch/ns:PmtInfId",
                 "./ns:NtryDtls/ns:TxDtls/ns:Refs/ns:AcctSvcrRef",
+                "./ns:AcctSvcrRef",
             ],
             transaction,
             "ref",
@@ -337,12 +338,21 @@ class AccountStatementImportCamtParser(models.AbstractModel):
 
         details_nodes = node.xpath("./ns:NtryDtls/ns:TxDtls", namespaces={"ns": ns})
         if len(details_nodes) == 0:
+            self.add_value_from_node(
+                ns, node, "./ns:AddtlNtryInf", transaction, "payment_ref"
+            )
             self.generate_narration(transaction)
             yield transaction
             return
         transaction_base = transaction
         for node in details_nodes:
             transaction = transaction_base.copy()
+            transaction["narration"] = transaction_base["narration"].copy()
+            detail_amount = self.parse_amount(ns, node)
+            if detail_amount != 0.0:
+                transaction["amount"] = detail_amount
+            elif len(details_nodes) == 1 and node.tag.endswith("TxDtls"):
+                transaction["amount"] = amount
             self.parse_transaction_details(ns, node, transaction)
             self.generate_narration(transaction)
             yield transaction
@@ -450,7 +460,7 @@ class AccountStatementImportCamtParser(models.AbstractModel):
                 root = None
         if root is None:
             raise ValueError("Not a valid xml file, or not an xml file at all.")
-        ns = root.tag[1 : root.tag.index("}")]
+        ns = root.tag[1 : root.tag.index("}")] if "}" in root.tag else ""
         self.check_version(ns, root)
         statements = []
         currency = None

--- a/account_statement_import_camt/tests/samples/golden-camt053-txdtls.pydata
+++ b/account_statement_import_camt/tests/samples/golden-camt053-txdtls.pydata
@@ -41,4 +41,20 @@
                      'partner_name': 'Banque Cantonale Vaudoise',
                      'payment_ref': '/',
                      'ref': '302388292000022222222222222',
-                     'transaction_type': 'PMNT-RCDT-VCOM'}]}])
+                     'transaction_type': 'PMNT-RCDT-VCOM'},
+                    {'account_number': 'CH4444000000123456789',
+                     'amount': 50.0,
+                     'date': '2017-03-22',
+                     'narration': 'Partner Name (RltdPties/Nm): Single Detail Debtor\n'
+                                  'Partner Account Number (RltdPties/Acct): CH4444000000123456789\n'
+                                  'Transaction Date (BookgDt): 2017-03-22\n'
+                                  'Reference: ENTRY-FALLBACK-REF\n'
+                                  'Communication: \n'
+                                  'Transaction Type (BkTxCd): \n'
+                                  'Additional Entry Information (AddtlNtryInf): ENTRY INFO SHOULD STAY IN NARRATION ONLY\n'
+                                  'Unstructured Reference (RmtInf/Ustrd): REM-ONE\n'
+                                  'Postal Address (PstlAdr): Address line 1',
+                     'partner_name': 'Single Detail Debtor',
+                     'payment_ref': 'REM-ONE',
+                     'ref': 'ENTRY-FALLBACK-REF',
+                     'transaction_type': ''}]}])

--- a/account_statement_import_camt/tests/samples/test-camt053-txdtls
+++ b/account_statement_import_camt/tests/samples/test-camt053-txdtls
@@ -209,6 +209,37 @@
         </NtryDtls>
         <AddtlNtryInf>CRÉDIT GROUPÉ BVR TRAITEMENT DU 22.03.2017 NUMÉRO CLIENT 01-70884-3 PAQUET ID: 123456CHCAFEBABE</AddtlNtryInf>
       </Ntry>
+      <Ntry>
+        <Amt Ccy="CHF">50.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <BookgDt>
+          <Dt>2017-03-22</Dt>
+        </BookgDt>
+        <AcctSvcrRef>ENTRY-FALLBACK-REF</AcctSvcrRef>
+        <NtryDtls>
+          <TxDtls>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Single Detail Debtor</Nm>
+                <PstlAdr>
+                  <AdrLine></AdrLine>
+                  <AdrLine>Address line 1</AdrLine>
+                </PstlAdr>
+              </Dbtr>
+              <DbtrAcct>
+                <Id>
+                  <IBAN>CH4444000000123456789</IBAN>
+                </Id>
+              </DbtrAcct>
+            </RltdPties>
+            <RmtInf>
+              <Ustrd></Ustrd>
+              <Ustrd>REM-ONE</Ustrd>
+            </RmtInf>
+          </TxDtls>
+        </NtryDtls>
+        <AddtlNtryInf>ENTRY INFO SHOULD STAY IN NARRATION ONLY</AddtlNtryInf>
+      </Ntry>
     </Stmt>
   </BkToCstmrStmt>
 </Document>


### PR DESCRIPTION
This pull request makes several improvements to the CAMT account statement parser, enhancing its robustness and accuracy when extracting transaction details from XML files. The changes focus on handling edge cases in XML parsing, improving reference extraction, and ensuring transaction details are parsed correctly.

**Reference and Value Extraction Improvements:**
* The list of XPath expressions for extracting transaction references now includes an additional path (`"./ns:AcctSvcrRef"`), improving coverage for different CAMT file structures.

**Transaction Details Handling:**
* If no transaction detail nodes are found, the parser now attempts to extract the payment reference from the `AddtlNtryInf` field, ensuring more complete data extraction.
* When iterating over transaction detail nodes, the parser now:
  - Copies the narration field to each transaction detail.
  - Sets the transaction amount based on the detail amount, if present, or falls back to the main amount if only one detail exists.
  - These changes improve accuracy when splitting or aggregating transaction details.