### PR TITLE
UPD camt parser to include charges in transaction details

### DIFF
--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -335,7 +335,13 @@ class AccountStatementImportCamtParser(models.AbstractModel):
             "-".join(transaction["transaction_type"].values()) or ""
         )
 
-        details_nodes = node.xpath("./ns:NtryDtls/ns:TxDtls", namespaces={"ns": ns})
+        tx_details_nodes = node.xpath("./ns:NtryDtls/ns:TxDtls", namespaces={"ns": ns})
+        details_nodes = list(tx_details_nodes)
+        details_nodes.extend(
+            node.xpath(
+                "./ns:Chrgs/ns:Rcrd[ns:ChrgInclInd='true']", namespaces={"ns": ns}
+            )
+        )
         if len(details_nodes) == 0:
             self.generate_narration(transaction)
             yield transaction


### PR DESCRIPTION
Updated the `parse_entry` method to include both transaction details (`TxDtls`) and charge records where charges are included (`Chrgs/Rcrd[ChrgInclInd='true']`) in the `details_nodes` list. This ensures that all relevant transaction and charge information is processed.