### PR TITLE
[18.0] ADD multicurrency support in CAMT parser

### DIFF
--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -19,7 +19,6 @@ class AccountStatementImportCamtParser(models.AbstractModel):
         if node is None:
             return 0.0
         sign = 1
-        amount = 0.0
         sign_node = node.xpath("ns:CdtDbtInd", namespaces={"ns": ns})
         if not sign_node:
             sign_node = node.xpath("../../ns:CdtDbtInd", namespaces={"ns": ns})
@@ -30,9 +29,77 @@ class AccountStatementImportCamtParser(models.AbstractModel):
             amount_node = node.xpath(
                 "./ns:AmtDtls/ns:TxAmt/ns:Amt", namespaces={"ns": ns}
             )
+            parent_amount_currency = node.xpath(
+                "../../ns:Amt/@Ccy", namespaces={"ns": ns}
+            )
+            if amount_node and parent_amount_currency:
+                amount_currency = amount_node[0].get("Ccy")
+                if amount_currency and amount_currency != parent_amount_currency[0]:
+                    amount_node = []
         if amount_node:
-            amount = sign * float(amount_node[0].text)
-        return amount
+            return sign * float(amount_node[0].text or 0.0)
+        return 0.0
+
+    def parse_amount_details_currency(self, ns, node, transaction):
+        """Extract original transaction currency details when available."""
+        statement_currency = transaction.get("currency")
+        original_currency = None
+        original_amount = 0.0
+
+        original_amount_nodes = node.xpath(
+            "./ns:AmtDtls/ns:TxAmt/ns:Amt[@Ccy] | .//ns:AmtDtls/ns:TxAmt/ns:Amt[@Ccy]",
+            namespaces={"ns": ns},
+        )
+        for amount_node in original_amount_nodes:
+            currency = amount_node.get("Ccy")
+            if currency and currency != statement_currency:
+                original_currency = currency
+                original_amount = float(amount_node.text or 0.0)
+                break
+
+        if not original_currency:
+            ccy_nodes = node.xpath(".//ns:AmtDtls//@Ccy", namespaces={"ns": ns})
+            for currency in ccy_nodes:
+                if currency == statement_currency:
+                    continue
+                value_node = node.xpath(
+                    f".//ns:AmtDtls//*[@Ccy='{currency}']",
+                    namespaces={"ns": ns},
+                )
+                if value_node:
+                    original_currency = currency
+                    original_amount = float(value_node[0].text or 0.0)
+                    break
+
+        if not original_currency:
+            trgt_ccy = node.xpath(".//ns:CcyXchg/ns:TrgtCcy", namespaces={"ns": ns})
+            rate = node.xpath(".//ns:CcyXchg/ns:XchgRate", namespaces={"ns": ns})
+            amount_node = node.xpath("ns:Amt", namespaces={"ns": ns})
+            if (
+                trgt_ccy
+                and rate
+                and amount_node
+                and trgt_ccy[0].text
+                and trgt_ccy[0].text != statement_currency
+            ):
+                original_currency = trgt_ccy[0].text
+                original_amount = float(amount_node[0].text or 0.0) * float(
+                    rate[0].text or 0.0
+                )
+
+        if not original_currency:
+            return False
+
+        currency = self.env["res.currency"].search(
+            [("name", "=", original_currency)], limit=1
+        )
+        if not currency:
+            return False
+
+        sign = 1 if transaction.get("amount", 0.0) >= 0 else -1
+        transaction["foreign_currency_id"] = currency.id
+        transaction["amount_currency"] = sign * abs(original_amount)
+        return True
 
     def add_value_from_node(self, ns, node, xpath_str, obj, attr_name, join_str=None):
         """Add value to object from first or all nodes found with xpath.
@@ -279,6 +346,13 @@ class AccountStatementImportCamtParser(models.AbstractModel):
         self.add_value_from_node(
             ns, node, "./ns:BookgDt/ns:Dt | ./ns:BookgDt/ns:DtTm", transaction, "date"
         )
+        self.add_value_from_node(
+            ns,
+            node,
+            ["./ns:Amt/@Ccy", ".//ns:AmtDtls/ns:TxAmt/ns:Amt/@Ccy"],
+            transaction,
+            "currency",
+        )
         amount = self.parse_amount(ns, node)
         if amount != 0.0:
             transaction["amount"] = amount
@@ -337,6 +411,8 @@ class AccountStatementImportCamtParser(models.AbstractModel):
 
         details_nodes = node.xpath("./ns:NtryDtls/ns:TxDtls", namespaces={"ns": ns})
         if len(details_nodes) == 0:
+            self.parse_amount_details_currency(ns, node, transaction)
+            transaction.pop("currency", None)
             self.generate_narration(transaction)
             yield transaction
             return
@@ -344,6 +420,11 @@ class AccountStatementImportCamtParser(models.AbstractModel):
         for node in details_nodes:
             transaction = transaction_base.copy()
             self.parse_transaction_details(ns, node, transaction)
+            if not self.parse_amount_details_currency(ns, node, transaction):
+                self.parse_amount_details_currency(
+                    ns, node.getparent().getparent(), transaction
+                )
+            transaction.pop("currency", None)
             self.generate_narration(transaction)
             yield transaction
 

--- a/account_statement_import_camt/tests/samples/golden-camt053-multicurrency.pydata
+++ b/account_statement_import_camt/tests/samples/golden-camt053-multicurrency.pydata
@@ -1,0 +1,19 @@
+('SEK',
+ 'SE3550000000054910000003',
+ [{'balance_end_real': 0.0,
+   'balance_start': 0.0,
+   'date': '2026-05-06',
+   'name': 'STATEMENT-1',
+   'transactions': [{'account_number': 'SE123456789',
+                     'amount': 345.34,
+                     'amount_currency': 32.0,
+                     'date': '2026-05-06',
+                     'foreign_currency_id': 'EUR',
+                     'narration': 'Partner Name (RltdPties/Nm): \n'
+                                  'Partner Account Number (RltdPties/Acct): SE123456789\n'
+                                  'Transaction Date (BookgDt): 2026-05-06\n'
+                                  'Reference: \n'
+                                  'Communication: \n'
+                                  'Transaction Type (BkTxCd): ',
+                     'payment_ref': '/',
+                     'transaction_type': ''}]}])

--- a/account_statement_import_camt/tests/samples/test-camt053-multicurrency
+++ b/account_statement_import_camt/tests/samples/test-camt053-multicurrency
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+  <BkToCstmrStmt>
+    <GrpHdr>
+      <MsgId>MULTI-1</MsgId>
+      <CreDtTm>2026-05-06T10:00:00</CreDtTm>
+    </GrpHdr>
+    <Stmt>
+      <Id>STATEMENT-1</Id>
+      <Acct>
+        <Id>
+          <IBAN>SE3550000000054910000003</IBAN>
+        </Id>
+        <Ccy>SEK</Ccy>
+      </Acct>
+      <Ntry>
+        <Amt Ccy="SEK">345.34</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <BookgDt>
+          <Dt>2026-05-06</Dt>
+        </BookgDt>
+        <NtryDtls>
+          <TxDtls>
+            <AmtDtls>
+              <TxAmt>
+                <Amt Ccy="EUR">32.00</Amt>
+              </TxAmt>
+            </AmtDtls>
+            <RltdPties>
+              <DbtrAcct>
+                <Id>
+                  <Othr>
+                    <Id>SE123456789</Id>
+                  </Othr>
+                </Id>
+              </DbtrAcct>
+            </RltdPties>
+          </TxDtls>
+        </NtryDtls>
+      </Ntry>
+    </Stmt>
+  </BkToCstmrStmt>
+</Document>
+

--- a/account_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_statement_import_camt/tests/test_import_bank_statement.py
@@ -19,7 +19,9 @@ class TestParserCommon(TransactionCase):
         super().setUpClass()
         cls.parser = cls.env["account.statement.import.camt.parser"]
 
-    def _do_parse_test(self, inputfile, goldenfile, max_diff_count=None):
+    def _do_parse_test(
+        self, inputfile, goldenfile, max_diff_count=None, normalize=False
+    ):
         """Imports ``inputfile`` and confronts its output against ``goldenfile`` data
 
         An AssertionError is raised if max_diff_count < 0
@@ -30,17 +32,37 @@ class TestParserCommon(TransactionCase):
         :type goldenfile: Path or str
         :param max_diff_count: maximum nr of lines that can differ (default: 2)
         :type max_diff_count: int
+        :param normalize: apply :meth:`_normalize_result` before comparison
+        :type normalize: bool
         """
         max_diff_count = max_diff_count or 2
         assert max_diff_count >= 0
-        diff = self._get_files_diffs(*map(self._to_filepath, (inputfile, goldenfile)))
+        diff = self._get_files_diffs(
+            *map(self._to_filepath, (inputfile, goldenfile)), normalize=normalize
+        )
         self.assertLessEqual(
             len(diff),
             max_diff_count,
             f"Actual output doesn't match expected output:\n{''.join(diff)}",
         )
 
-    def _get_files_diffs(self, inputfile_path, goldenfile_path) -> list:
+    def _normalize_result(self, result):
+        """Normalize parsed result for stable golden-file comparison.
+
+        Replaces ``foreign_currency_id`` integer database IDs with the ISO
+        currency name so that golden files are portable across databases.
+        """
+        _currency, _account, statements = result
+        for stmt in statements:
+            for txn in stmt.get("transactions", []):
+                if isinstance(txn.get("foreign_currency_id"), int):
+                    rec = self.env["res.currency"].browse(txn["foreign_currency_id"])
+                    txn["foreign_currency_id"] = rec.name
+        return result
+
+    def _get_files_diffs(
+        self, inputfile_path, goldenfile_path, normalize=False
+    ) -> list:
         """Creates diffs between ``inputfile_path`` and ``goldenfile_path`` data
 
         :param inputfile_path: path for file to import and test
@@ -48,11 +70,15 @@ class TestParserCommon(TransactionCase):
         :param goldenfile_path: path for file to use for comparison
                                 (the expected values)
         :type goldenfile_path: Path
+        :param normalize: apply :meth:`_normalize_result` before comparison
+        :type normalize: bool
         """
 
         # Read the input file, store the actual imported values
         with open(file_path(inputfile_path), "rb") as inputf:
             res = self.parser.parse(inputf.read())
+        if normalize:
+            res = self._normalize_result(res)
         # Read the output file, store the expected imported values
         with open(file_path(goldenfile_path)) as goldf:
             gold_name, gold_lines = goldf.name, goldf.readlines()
@@ -83,6 +109,32 @@ class TestParserCommon(TransactionCase):
 class TestParser(TestParserCommon):
     """Tests for the camt parser itself."""
 
+    def _parse_single_tx_from_inline_camt(self, ntry_xml, account_currency="EUR"):
+        camt_data = f"""<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02">
+  <BkToCstmrStmt>
+    <GrpHdr>
+      <MsgId>INLINE-1</MsgId>
+      <CreDtTm>2026-05-06T10:00:00</CreDtTm>
+    </GrpHdr>
+    <Stmt>
+      <Id>STATEMENT-1</Id>
+      <Acct>
+        <Id>
+          <IBAN>SE3550000000054910000003</IBAN>
+        </Id>
+        <Ccy>{account_currency}</Ccy>
+      </Acct>
+      {ntry_xml}
+    </Stmt>
+  </BkToCstmrStmt>
+</Document>
+"""
+        currency, account_number, statements = self.parser.parse(camt_data.encode())
+        self.assertEqual(len(statements), 1)
+        self.assertEqual(len(statements[0]["transactions"]), 1)
+        return currency, account_number, statements[0]["transactions"][0]
+
     def test_parse(self):
         self._do_parse_test("test-camt053", "golden-camt053.pydata")
 
@@ -94,6 +146,109 @@ class TestParser(TestParserCommon):
 
     def test_parse_no_ntry(self):
         self._do_parse_test("test-camt053-no-ntry", "golden-camt053-no-ntry.pydata")
+
+    def test_parse_multicurrency_amount_details(self):
+        self.env.ref("base.EUR").write({"active": True})
+        self.env.ref("base.SEK").write({"active": True})
+        self._do_parse_test(
+            "test-camt053-multicurrency",
+            "golden-camt053-multicurrency.pydata",
+            normalize=True,
+        )
+
+    def test_parse_multicurrency_amount_details_ccyxchg(self):
+        self.env.ref("base.EUR").write({"active": True})
+        self.env.ref("base.SEK").write({"active": True})
+
+        _, _, transaction = self._parse_single_tx_from_inline_camt(
+            """
+<Ntry>
+  <Amt Ccy="SEK">100.00</Amt>
+  <CdtDbtInd>DBIT</CdtDbtInd>
+  <BookgDt>
+    <Dt>2026-05-06</Dt>
+  </BookgDt>
+  <NtryDtls>
+    <TxDtls>
+      <Amt Ccy="SEK">100.00</Amt>
+      <CcyXchg>
+        <TrgtCcy>EUR</TrgtCcy>
+        <XchgRate>0.10</XchgRate>
+      </CcyXchg>
+    </TxDtls>
+  </NtryDtls>
+</Ntry>
+""",
+            account_currency="SEK",
+        )
+
+        self.assertEqual(transaction["amount"], -100.0)
+        self.assertEqual(transaction["amount_currency"], -10.0)
+        self.assertEqual(
+            transaction["foreign_currency_id"], self.env.ref("base.EUR").id
+        )
+
+    def test_parse_multicurrency_amount_details_amtdtls_fallback(self):
+        self.env.ref("base.EUR").write({"active": True})
+        self.env.ref("base.USD").write({"active": True})
+
+        _, _, transaction = self._parse_single_tx_from_inline_camt(
+            """
+<Ntry>
+  <Amt Ccy="EUR">100.00</Amt>
+  <CdtDbtInd>CRDT</CdtDbtInd>
+  <BookgDt>
+    <Dt>2026-05-06</Dt>
+  </BookgDt>
+  <NtryDtls>
+    <TxDtls>
+      <Amt Ccy="EUR">100.00</Amt>
+      <AmtDtls>
+        <InstdAmt>
+          <Amt Ccy="USD">110.00</Amt>
+        </InstdAmt>
+      </AmtDtls>
+    </TxDtls>
+  </NtryDtls>
+</Ntry>
+""",
+            account_currency="EUR",
+        )
+
+        self.assertEqual(transaction["amount"], 100.0)
+        self.assertEqual(transaction["amount_currency"], 110.0)
+        self.assertEqual(
+            transaction["foreign_currency_id"], self.env.ref("base.USD").id
+        )
+
+    def test_parse_multicurrency_amount_details_unknown_currency(self):
+        self.env.ref("base.SEK").write({"active": True})
+
+        _, _, transaction = self._parse_single_tx_from_inline_camt(
+            """
+<Ntry>
+  <Amt Ccy="SEK">345.34</Amt>
+  <CdtDbtInd>CRDT</CdtDbtInd>
+  <BookgDt>
+    <Dt>2026-05-06</Dt>
+  </BookgDt>
+  <NtryDtls>
+    <TxDtls>
+      <AmtDtls>
+        <TxAmt>
+          <Amt Ccy="ZZZ">32.00</Amt>
+        </TxAmt>
+      </AmtDtls>
+    </TxDtls>
+  </NtryDtls>
+</Ntry>
+""",
+            account_currency="SEK",
+        )
+
+        self.assertEqual(transaction["amount"], 345.34)
+        self.assertNotIn("amount_currency", transaction)
+        self.assertNotIn("foreign_currency_id", transaction)
 
 
 class TestImport(TransactionCase):
@@ -154,6 +309,9 @@ class TestImport(TransactionCase):
                 "type": "bank",
                 "bank_account_id": bank.id,
                 "currency_id": eur.id,
+                "suspense_account_id": (
+                    cls.env.company.account_journal_suspense_account_id.id
+                ),
             }
         )
 


### PR DESCRIPTION
This enables the CAMT parser to parse bank statements in foreign currencies.