### PR TITLE
UPD camt parser: enhance party name resolution

### DIFF
--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -190,13 +190,19 @@ class AccountStatementImportCamtParser(models.AbstractModel):
         party_type_node = node.xpath("../../ns:CdtDbtInd", namespaces={"ns": ns})
         if party_type_node and party_type_node[0].text != "CRDT":
             party_type = "Cdtr"
+        party_name_type = party_type
+        ultimate_party_type = f"Ultmt{party_type}"
+        if node.xpath(
+            f"./ns:RltdPties/ns:{ultimate_party_type}", namespaces={"ns": ns}
+        ):
+            party_name_type = ultimate_party_type
         party_node = node.xpath(
-            f"./ns:RltdPties/ns:{party_type}", namespaces={"ns": ns}
+            f"./ns:RltdPties/ns:{party_name_type}", namespaces={"ns": ns}
         )
         if party_node:
             name_node = node.xpath(
-                f"./ns:RltdPties/ns:{party_type}/ns:Nm |"
-                f"./ns:RltdPties/ns:{party_type}/ns:Pty/ns:Nm",
+                f"./ns:RltdPties/ns:{party_name_type}/ns:Nm |"
+                f"./ns:RltdPties/ns:{party_name_type}/ns:Pty/ns:Nm",
                 namespaces={"ns": ns},
             )
             if name_node:

--- a/account_statement_import_camt/tests/samples/golden-camt053-txdtls.pydata
+++ b/account_statement_import_camt/tests/samples/golden-camt053-txdtls.pydata
@@ -7,7 +7,7 @@
    'transactions': [{'account_number': 'CH2222000000123456789',
                      'amount': 2187.0,
                      'date': '2017-03-22',
-                     'narration': 'Partner Name (RltdPties/Nm): Banque Cantonale Vaudoise\n'
+                     'narration': 'Partner Name (RltdPties/Nm): Ultimate Payer Ltd\n'
                                   'Partner Account Number (RltdPties/Acct): CH2222000000123456789\n'
                                   'Transaction Date (BookgDt): 2017-03-22\n'
                                   'Reference: 302388292000011111111111111\n'
@@ -17,9 +17,8 @@
                                   '123456CHCAFEBABE\n'
                                   'Reversal Indicator (RvslInd): false\n'
                                   'Structured Reference (RmtInf/Strd/CdtrRefInf/Ref): 302388292000011111111111111\n'
-                                  'Account Servicer Reference (Refs/AcctSvcrRef): 123456CHCAFEBABE\n'
-                                  'Postal Address (PstlAdr): Place Saint-François | 14 | 1003 | Lausanne | CH1',
-                     'partner_name': 'Banque Cantonale Vaudoise',
+                                  'Account Servicer Reference (Refs/AcctSvcrRef): 123456CHCAFEBABE',
+                     'partner_name': 'Ultimate Payer Ltd',
                      'payment_ref': '/',
                      'ref': '302388292000011111111111111',
                      'transaction_type': 'PMNT-RCDT-VCOM'},

--- a/account_statement_import_camt/tests/samples/test-camt053-txdtls
+++ b/account_statement_import_camt/tests/samples/test-camt053-txdtls
@@ -96,6 +96,9 @@
               </Domn>
             </BkTxCd>
             <RltdPties>
+              <UltmtDbtr>
+                <Nm>Ultimate Payer Ltd</Nm>
+              </UltmtDbtr>
               <Dbtr>
                 <Nm>Banque Cantonale Vaudoise</Nm>
                 <PstlAdr>


### PR DESCRIPTION
This updates the logic for parsing transaction details : it now correctly handles cases where the "ultimate" party (e.g., `UltmtCdtr` or `UltmtDbtr`) is present in the XML, preferring it over the regular party node when available.