### PR TITLE
[19.0][I18N] account_statement_import_qif: Add Chinese (zh_CN) translation

### DIFF
--- a/account_statement_import_qif/i18n/zh_CN.po
+++ b/account_statement_import_qif/i18n/zh_CN.po
@@ -1,0 +1,55 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* account_statement_import_qif
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2026-05-12 16:30+0000\n"
+"Last-Translator: Moneeeeee <monee@fountain.top>\n"
+"Language-Team: Chinese (Simplified) (https://www.transifex.com/oca/teams/23907/zh_CN/)\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: account_statement_import_qif
+#. odoo-python
+#: code:addons/account_statement_import_qif/wizards/account_statement_import_qif.py:0
+msgid "Could not decipher the QIF file."
+msgstr "无法解析该 QIF 文件。"
+
+#. module: account_statement_import_qif
+#: model:ir.model.fields,field_description:account_statement_import_qif.field_account_journal__display_name
+#: model:ir.model.fields,field_description:account_statement_import_qif.field_account_statement_import__display_name
+msgid "Display Name"
+msgstr "显示名称"
+
+#. module: account_statement_import_qif
+#: model:ir.model.fields,field_description:account_statement_import_qif.field_account_journal__id
+#: model:ir.model.fields,field_description:account_statement_import_qif.field_account_statement_import__id
+msgid "ID"
+msgstr "ID"
+
+#. module: account_statement_import_qif
+#: model:ir.model,name:account_statement_import_qif.model_account_statement_import
+msgid "Import Bank Statement Files"
+msgstr "导入银行对账单文件"
+
+#. module: account_statement_import_qif
+#: model:ir.model,name:account_statement_import_qif.model_account_journal
+msgid "Journal"
+msgstr "日记账"
+
+#. module: account_statement_import_qif
+#: model_terms:ir.ui.view,arch_db:account_statement_import_qif.account_statement_import_form
+msgid "Quicken Interchange Format (.qif)"
+msgstr "Quicken 交换格式 (.qif)"
+
+#. module: account_statement_import_qif
+#. odoo-python
+#: code:addons/account_statement_import_qif/wizards/account_statement_import_qif.py:0
+msgid "This file is either not a bank statement or is not correctly formed."
+msgstr "该文件不是银行对账单，或格式不正确。"


### PR DESCRIPTION
Adds Chinese Simplified (zh_CN) translation for account_statement_import_qif (7 translatable strings).

Tested locally on Odoo 19.0 Community with --i18n-overwrite; translation file loads successfully and module remainsfunctional.
Follow-up: I will add a translation for account_statement_import_camt in this same PR once style is confirmed.
