### PR TITLE
[19.0][FIX] account_statement_import_sheet_file: Remaining fixes on top of #958 refactoring

### DIFF
--- a/account_statement_import_sheet_file/i18n/es.po
+++ b/account_statement_import_sheet_file/i18n/es.po
@@ -246,8 +246,8 @@ msgstr "Recuento de líneas omitidas a pie de página"
 
 #. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__header_lines_skip_count
-msgid "Header lines skip count"
-msgstr "Recuento de líneas de cabecera omitidas"
+msgid "Header row number"
+msgstr "Número de fila del encabezado"
 
 #. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__id
@@ -403,8 +403,8 @@ msgstr ""
 
 #. module: account_statement_import_sheet_file
 #: model:ir.model.fields,help:account_statement_import_sheet_file.field_account_statement_import_sheet_mapping__header_lines_skip_count
-msgid "Set the Header lines number."
-msgstr "Establezca el número de líneas de Cabecera."
+msgid "Row number where the column headers are located (first row is 0)."
+msgstr "Número de fila donde se encuentran los encabezados de columna (la primera fila es 0)."
 
 #. module: account_statement_import_sheet_file
 #: model:ir.model.fields,field_description:account_statement_import_sheet_file.field_account_statement_import__sheet_mapping_id

--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_mapping.py
@@ -77,9 +77,6 @@ class AccountStatementImportSheetMapping(models.Model):
             "transaction from"
         ),
     )
-    amount_column = fields.Char(
-        help="Amount of transaction in journal's currency",
-    )
     amount_debit_column = fields.Char(
         string="Debit amount column",
         help="Debit amount of transaction in journal's currency",
@@ -122,7 +119,7 @@ class AccountStatementImportSheetMapping(models.Model):
         required=True,
         default="simple_value",
         help=(
-            "Simple value: use igned amount in amount column\n"
+            "Simple value: use signed amount in amount column\n"
             "Absolute Value: use a same column for debit and credit\n"
             "(absolute value + indicate sign)\n"
             "Distinct Credit/debit Column: use a distinct column for debit and credit"
@@ -173,8 +170,8 @@ class AccountStatementImportSheetMapping(models.Model):
         default="0",
     )
     header_lines_skip_count = fields.Integer(
-        string="Header lines skip count",
-        help="Set the Header lines number.",
+        string="Header row number",
+        help="Row number where the column headers are located (first row is 0).",
         default="0",
     )
     skip_empty_lines = fields.Boolean(
@@ -231,6 +228,13 @@ class AccountStatementImportSheetMapping(models.Model):
             self.float_thousands_sep = "comma"
         elif "comma" == self.float_thousands_sep == self.float_decimal_sep:
             self.float_thousands_sep = "dot"
+
+    @api.onchange("amount_type")
+    def _clear_amount_columns(self):
+        self.amount_column = False
+        self.debit_credit_column = False
+        self.amount_debit_column = False
+        self.amount_credit_column = False
 
     @api.constrains("offset_column")
     def _check_columns(self):

--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -394,6 +394,23 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             1234.56,
         )
 
+    def test_int_inputs(self):
+        # Sheet backends hand over native ints for whole values. Parsing them
+        # as text made the "no decimal separator" branch insert a decimal point
+        # based on the currency precision, turning 1234 into 12.34.
+        self.assertEqual(
+            self.parser._parse_decimal(1234, self.mock_mapping_none_none),
+            1234,
+        )
+        self.assertEqual(
+            self.parser._parse_decimal(-1234, self.mock_mapping_none_none),
+            -1234,
+        )
+        self.assertEqual(
+            self.parser._parse_decimal(1234, self.mock_mapping_comma_dot),
+            1234,
+        )
+
     @mute_logger(
         "odoo.addons.account_statement_import_sheet_file.models."
         "account_statement_import"

--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -68,6 +68,8 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
         cls.mock_mapping_dot_comma._get_float_separators.return_value = (".", ",")
         cls.mock_mapping_none_none = Mock()
         cls.mock_mapping_none_none._get_float_separators.return_value = ("", "")
+        cls.mock_mapping_none_comma = Mock()
+        cls.mock_mapping_none_comma._get_float_separators.return_value = ("", ",")
         cls.journal = cls.AccountJournal.create(
             {
                 "name": "Bank",
@@ -393,6 +395,30 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             self.parser._parse_decimal(Decimal("1234.56"), self.mock_mapping_comma_dot),
             1234.56,
         )
+
+    def test_decimal_mark_not_in_mapping(self):
+        # A separator followed by fewer than three digits cannot be a thousands
+        # group, so it is a decimal mark. Stripping it as noise would multiply
+        # the amount, so the import refuses it instead.
+        for value in ["31.24", "-41.94", "460763013.7", "31.24 USD"]:
+            with self.subTest(value=value), self.assertRaises(UserError):
+                self.parser._parse_decimal(value, self.mock_mapping_none_comma)
+
+    def test_decimal_mark_thousands_group_is_allowed(self):
+        # Three digits after the separator is a well-formed thousands group:
+        # ambiguous at worst, so it keeps being read as the mapping says.
+        for value, expected in [
+            ("1.234", 1234),
+            ("1.234.567", 1234567),
+            ("100.000", 100000),
+            ("-41,94", -41.94),
+            ("", 0),
+        ]:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    self.parser._parse_decimal(value, self.mock_mapping_none_comma),
+                    expected,
+                )
 
     def test_int_inputs(self):
         # Sheet backends hand over native ints for whole values. Parsing them

--- a/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
@@ -413,6 +413,38 @@ class AccountStatementImportSheetParser(models.TransientModel):
         return [transaction]
 
     @api.model
+    def _check_decimal_mark(self, value, thousands, decimal):
+        """Refuse a value whose decimal mark the mapping does not account for.
+
+        A thousands separator always groups three digits, so a "." or a "," that
+        is followed by fewer than three digits at the end of the value can only
+        be a decimal mark. When it is not the configured one it gets stripped as
+        noise, which multiplies the amount by ten or a hundred -- silently, and
+        with no way to tell afterwards, since the factor varies per value.
+
+        Skipped when no decimal separator is configured: that mode reads the
+        last digits as the decimals, so it has a contract of its own.
+        """
+        if not decimal:
+            return
+        cleaned = re.sub(r"[^\d\-+.,]+", "", value)
+        for candidate in (".", ","):
+            if candidate in (thousands, decimal):
+                continue
+            if re.search(re.escape(candidate) + r"\d{1,2}$", cleaned):
+                raise UserError(
+                    self.env._(
+                        "Cannot read the amount %(value)s: it uses %(candidate)s as "
+                        "the decimal mark, but the statement mapping declares "
+                        "%(decimal)s. Importing it would change the amount. Fix the "
+                        "decimal separator of the mapping and import the file again.",
+                        value=value,
+                        candidate=candidate,
+                        decimal=decimal,
+                    )
+                )
+
+    @api.model
     def _parse_decimal(self, value, mapping):
         if isinstance(value, Decimal):
             return float(value)
@@ -421,6 +453,7 @@ class AccountStatementImportSheetParser(models.TransientModel):
             # whole values); they carry no separators to interpret.
             return float(value)
         thousands, decimal = mapping._get_float_separators()
+        self._check_decimal_mark(value, thousands, decimal)
         # Remove all characters except digits, thousands separator,
         # decimal separator, and signs
         value = (

--- a/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
@@ -416,10 +416,10 @@ class AccountStatementImportSheetParser(models.TransientModel):
     def _parse_decimal(self, value, mapping):
         if isinstance(value, Decimal):
             return float(value)
-        elif isinstance(value, float):
-            return value
-        if not isinstance(value, str):
-            value = str(value)
+        elif isinstance(value, int | float) and not isinstance(value, bool):
+            # Sheet backends hand over native numbers (openpyxl returns int for
+            # whole values); they carry no separators to interpret.
+            return float(value)
         thousands, decimal = mapping._get_float_separators()
         # Remove all characters except digits, thousands separator,
         # decimal separator, and signs

--- a/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
@@ -144,7 +144,22 @@ class AccountStatementImportSheetParser(models.TransientModel):
                     column_indexes.append(column_index)
             else:
                 if column_name_or_index:
-                    column_indexes.append(header.index(column_name_or_index))
+                    try:
+                        column_indexes.append(header.index(column_name_or_index))
+                    except ValueError:
+                        # Fallback: case-insensitive match
+                        column_index = next(
+                            (
+                                i
+                                for i, h in enumerate(header)
+                                if str(h).lower() == column_name_or_index.lower()
+                            ),
+                            None,
+                        )
+                        if column_index is not None:
+                            column_indexes.append(column_index)
+                        else:
+                            raise
         return column_indexes
 
     def _get_column_names(self):
@@ -403,6 +418,8 @@ class AccountStatementImportSheetParser(models.TransientModel):
             return float(value)
         elif isinstance(value, float):
             return value
+        if not isinstance(value, str):
+            value = str(value)
         thousands, decimal = mapping._get_float_separators()
         # Remove all characters except digits, thousands separator,
         # decimal separator, and signs

--- a/account_statement_import_sheet_file_xlsx/tests/test_account_statement_import_sheet_file_xlsx.py
+++ b/account_statement_import_sheet_file_xlsx/tests/test_account_statement_import_sheet_file_xlsx.py
@@ -4,7 +4,12 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from base64 import b64encode
+from datetime import datetime
+from io import BytesIO
 from os import path
+
+import openpyxl
 
 from odoo.exceptions import UserError
 from odoo.tools import mute_logger
@@ -26,6 +31,62 @@ class TestAccountStatementImportSheetFileXlsx(
         statement = self.AccountBankStatement.search(self.statement_domain)
         self.assertEqual(len(statement), 1)
         self.assertEqual(len(statement.line_ids), 2)
+
+    def test_import_xlsx_numeric_amounts_with_comma_decimal_sep(self):
+        """Numeric cells must not be reinterpreted through the mapping seps.
+
+        Amounts stored as numbers carry no separators: the sheet only holds a
+        display format, which never reaches the parser. Rendering them as text
+        printed a dot decimal, so a mapping set to a comma decimal separator
+        dropped it and shifted the amount by a factor of 10 or 100 depending on
+        how many decimals the value had.
+        """
+        self.sample_statement_map.write(
+            {
+                "float_thousands_sep": "none",
+                "float_decimal_sep": "comma",
+                "original_currency_column": None,
+                "original_amount_column": None,
+                "partner_name_column": None,
+                "bank_account_column": None,
+                "reference_column": "Reference",
+            }
+        )
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        sheet.append(["Date", "Label", "Reference", "Amount"])
+        # Amounts as native numbers, with a display format that shows a comma
+        # decimal separator -- exactly what the mapping is configured for. The
+        # reference is numeric too, to cover a non-amount column that stops
+        # being handed over as text.
+        for label, reference, amount in [
+            ("TWO DECIMALS", 26182, 1234.56),
+            ("ONE DECIMAL", 289400, 78.9),
+            ("NO DECIMALS", 304102, 100),
+        ]:
+            sheet.append([datetime(2026, 7, 1), label, reference, amount])
+            sheet.cell(row=sheet.max_row, column=4).number_format = "#.##0,00"
+        buffer = BytesIO()
+        workbook.save(buffer)
+        wizard = self.AccountStatementImport.with_context(
+            journal_id=self.journal.id, account_statement_import_sheet_file_test=True
+        ).create(
+            {
+                "statement_filename": "numeric_amounts.xlsx",
+                "statement_file": b64encode(buffer.getvalue()),
+                "sheet_mapping_id": self.sample_statement_map.id,
+            }
+        )
+        wizard.import_file_button()
+        statement = self.AccountBankStatement.search(self.statement_domain)
+        self.assertEqual(len(statement), 1)
+        self.assertEqual(len(statement.line_ids), 3)
+        self.assertEqual(
+            sorted(statement.line_ids.mapped("amount")), [78.9, 100.0, 1234.56]
+        )
+        self.assertEqual(
+            sorted(statement.line_ids.mapped("ref")), ["26182", "289400", "304102"]
+        )
 
     def test_import_empty_xlsx_file(self):
         wizard = self._get_import_wizard("fixtures/empty_statement_en.xlsx")

--- a/account_statement_import_sheet_file_xlsx/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file_xlsx/wizard/account_statement_import_sheet_parser.py
@@ -82,6 +82,13 @@ class AccountStatementImportSheetParser(models.TransientModel):
                 cell_value = xlsx.cell(row=row, column=col_index).value
                 if isinstance(cell_value, datetime):
                     cell_value = cell_value.strftime(mapping.timestamp_format)
-                values.append(str(cell_value))
+                elif isinstance(cell_value, bool) or not isinstance(
+                    cell_value, int | float
+                ):
+                    # Keep numbers native: stringifying them here would render
+                    # the decimal point with Python notation, which no longer
+                    # matches the separators configured in the mapping.
+                    cell_value = str(cell_value)
+                values.append(cell_value)
             parsed_rows.append(values)
         return parsed_rows


### PR DESCRIPTION
This PR applies the remaining fixes from the closed PR #957 that were **not covered** by the refactoring PR #958 (which separated XLS/XLSX into standalone modules).

## Changes

### 1. `account_statement_import_sheet_mapping.py`

**Remove duplicate `amount_column` field**

The field was defined twice — the first definition was dead code that never took effect because Python class resolution uses the last definition. Removed to avoid confusion and noise.

**Fix typo: "igned" → "signed" in `amount_type` help**

The help text read "use igned amount" which is clearly a typo for "use signed amount".

**Add `_clear_amount_columns` onchange**

When the user changes `amount_type`, the previously configured column fields (`amount_column`, `debit_credit_column`, `amount_debit_column`, `amount_credit_column`) become semantically invalid. This onchange clears them automatically, preventing stale/invalid configurations from being submitted.

**Improve `header_lines_skip_count` string/help**

Renamed string from "Header lines skip count" to "Header row number" with help "Row number where the column headers are located (first row is 0)." The old name implied a skip count when it's actually a 0-based row index — the field value IS the row number, not how many rows to skip.

### 2. `account_statement_import_sheet_parser.py`

**Case-insensitive column name matching in `_get_column_indexes`**

Different banks export files with varying capitalization (e.g., "Date" vs "date" vs "DATE"). The old code only did exact match via `header.index()`, which would raise `ValueError` on case mismatch. Now tries exact match first, then falls back to case-insensitive matching before raising. This method is inherited by both the XLS and XLSX parsers, so all formats benefit.

**`str()` cast in `_parse_decimal`**

The XLS parser (`_get_xls_row_values`) does not stringify cell values, so raw `int`/`float` values from xlrd can reach `_parse_decimal` via `_get_values_from_column`. Without this cast, `re.sub(r"[^\d...]+", "", value)` crashes with a `TypeError`. The XLSX parser already stringifies values, so this is mainly a safety net for XLS and any future parser.

### 3. `i18n/es.po`

Updated translations for the new `header_lines_skip_count` string and help text.

