### PR TITLE
[18.0][FIX] account_statement_import_sheet_file: Avoid set an empty balance

### DIFF
--- a/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py
@@ -346,10 +346,8 @@ class AccountStatementImportSheetParser(models.TransientModel):
                         year -= 1
                     timestamp = timestamp.replace(year=year)
 
-            if balance:
+            if balance is not None:
                 balance = self._parse_decimal(balance, mapping)
-            else:
-                balance = None
 
             if debit_credit is not None:
                 amount = abs(amount)


### PR DESCRIPTION
Avoid set an empty balance

```
File \"/opt/odoo/auto/addons/account_statement_import_sheet_file/models/account_statement_import_sheet_parser.py\", line 86, in parse
   balance_end = last_line[\"balance\"]
   KeyError: 'balance'
   The above exception was the direct cause of the following exception:

```
Use case example:
- We have a file (e.g., .xlsx)
- The file contains a 0.00 in the Balance column specified in the mapping
- It is important to preserve that value, especially if it is the last line

Please @pedrobaeza and @Andrii9090-tecnativa can you review it?

@Tecnativa TT63516