### PR TITLE
[18.0][ADD] account_statement_import_camt: Fill payment_ref field from bank statement using simplified AddtlNtryInf tag

### DIFF
--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -337,6 +337,13 @@ class AccountStatementImportCamtParser(models.AbstractModel):
 
         details_nodes = node.xpath("./ns:NtryDtls/ns:TxDtls", namespaces={"ns": ns})
         if len(details_nodes) == 0:
+            addtl_info = node.xpath("./ns:AddtlNtryInf", namespaces={"ns": ns})
+            if (
+                addtl_info
+                and addtl_info[0].text
+                and transaction.get("payment_ref") == "/"
+            ):
+                transaction["payment_ref"] = addtl_info[0].text.strip()
             self.generate_narration(transaction)
             yield transaction
             return

--- a/account_statement_import_camt/tests/samples/golden-camt053-no-txdtls.pydata
+++ b/account_statement_import_camt/tests/samples/golden-camt053-no-txdtls.pydata
@@ -1,0 +1,27 @@
+('EUR',
+ 'BE00000000000000',
+ [{'balance_end_real': 100.0,
+   'balance_start': 0.0,
+   'date': '2026-06-28T21:40:58.810767+02:00',
+   'name': '52995589-87806609-1783466312332',
+   'transactions': [{'amount': -900.0,
+                     'date': '2026-06-28T21:40:58.810767+02:00',
+                     'narration': 'Partner Name (RltdPties/Nm): \n'
+                                  'Partner Account Number (RltdPties/Acct): \n'
+                                  'Transaction Date (BookgDt): 2026-06-28T21:40:58.810767+02:00\n'
+                                  'Reference: \n'
+                                  'Communication: \n'
+                                  'Transaction Type (BkTxCd): \n'
+                                  'Additional Entry Information (AddtlNtryInf): Card transaction of 900.00 EUR issued by Provider',
+                     'payment_ref': 'Card transaction of 900.00 EUR issued by Provider',
+                     'transaction_type': ''},
+                    {'amount': 1000.0,
+                     'date': '2026-06-03T09:52:08.054666+02:00',
+                     'narration': 'Partner Name (RltdPties/Nm): \n'
+                                  'Partner Account Number (RltdPties/Acct): \n'
+                                  'Transaction Date (BookgDt): 2026-06-03T09:52:08.054666+02:00\n'
+                                  'Reference: \n'
+                                  'Communication: \n'
+                                  'Transaction Type (BkTxCd): ',
+                     'payment_ref': '/',
+                     'transaction_type': ''}]}])

--- a/account_statement_import_camt/tests/samples/test-camt053-no-txdtls
+++ b/account_statement_import_camt/tests/samples/test-camt053-no-txdtls
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.10">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>52995589-1783466312332</MsgId>
+            <CreDtTm>2026-07-07T23:18:32.332104506Z</CreDtTm>
+        </GrpHdr>
+        <Stmt>
+            <Id>52995589-87806609-1783466312332</Id>
+            <CreDtTm>2026-07-07T23:18:32.332104506Z</CreDtTm>
+            <FrToDt>
+                <FrDtTm>2026-06-01T00:00:00+02:00</FrDtTm>
+                <ToDtTm>2026-07-01T00:00:00+02:00</ToDtTm>
+            </FrToDt>
+            <Acct>
+                <Id>
+                    <IBAN>BE00000000000000</IBAN>
+                </Id>
+                <Ccy>EUR</Ccy>
+                <Ownr>
+                    <Nm>ACME Corporation</Nm>
+                    <PstlAdr>
+                        <AdrTp>
+                            <Cd>ADDR</Cd>
+                        </AdrTp>
+                        <PstCd>12345</PstCd>
+                        <TwnNm>Springfield</TwnNm>
+                        <AdrLine>Fake Str. 123</AdrLine>
+                    </PstlAdr>
+                    <Id>
+                        <OrgId>
+                            <Othr>
+                                <Id>B12345678</Id>
+                                <SchmeNm>
+                                    <Cd>COID</Cd>
+                                </SchmeNm>
+                            </Othr>
+                        </OrgId>
+                    </Id>
+                </Ownr>
+                <Svcr>
+                    <FinInstnId>
+                        <Nm>Wise Europe SA</Nm>
+                        <PstlAdr>
+                            <AdrTp>
+                                <Cd>ADDR</Cd>
+                            </AdrTp>
+                            <PstCd>1050</PstCd>
+                            <TwnNm>Brussels</TwnNm>
+                            <AdrLine>Rue du Trône 100, 3rd floor</AdrLine>
+                        </PstlAdr>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">100.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <DtTm>2026-07-01T00:00:00+02:00</DtTm>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <DtTm>2026-06-01T00:00:00+02:00</DtTm>
+                </Dt>
+            </Bal>
+            <TxsSummry>
+                <TtlNtries>
+                    <NbOfNtries>2</NbOfNtries>
+                    <Sum>100.00</Sum>
+                    <TtlNetNtry>
+                        <Amt>100.00</Amt>
+                        <CdtDbtInd>CRDT</CdtDbtInd>
+                    </TtlNetNtry>
+                </TtlNtries>
+                <TtlCdtNtries>
+                    <NbOfNtries>1</NbOfNtries>
+                    <Sum>1000.00</Sum>
+                </TtlCdtNtries>
+                <TtlDbtNtries>
+                    <NbOfNtries>1</NbOfNtries>
+                    <Sum>900.00</Sum>
+                </TtlDbtNtries>
+            </TxsSummry>
+            <Ntry>
+                <Amt Ccy="EUR">900.00</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Sts>
+                    <Cd>BOOK</Cd>
+                </Sts>
+                <BookgDt>
+                    <DtTm>2026-06-28T21:40:58.810767+02:00</DtTm>
+                </BookgDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>CARD-0123456789</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <AddtlNtryInf>Card transaction of 900.00 EUR issued by Provider</AddtlNtryInf>
+            </Ntry>
+            <Ntry>
+                <Amt Ccy="EUR">1000.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>
+                    <Cd>BOOK</Cd>
+                </Sts>
+                <BookgDt>
+                    <DtTm>2026-06-03T09:52:08.054666+02:00</DtTm>
+                </BookgDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>14f0b58de0089edb1ef85f57ffc5052d</Cd>
+                    </Prtry>
+                </BkTxCd>
+            </Ntry>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>

--- a/account_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_statement_import_camt/tests/test_import_bank_statement.py
@@ -95,6 +95,9 @@ class TestParser(TestParserCommon):
     def test_parse_no_ntry(self):
         self._do_parse_test("test-camt053-no-ntry", "golden-camt053-no-ntry.pydata")
 
+    def test_parse_no_txdtls(self):
+        self._do_parse_test("test-camt053-no-txdtls", "golden-camt053-no-txdtls.pydata")
+
 
 class TestImport(TransactionCase):
     """Run test to import camt import."""


### PR DESCRIPTION
This PR extends que CAMT.053 parser to extract payment_ref data from CAMT.053 valid files that use a simplified AddtlNtryInf tag for storing information about the transaction. This applies to Wise bank statements in format CAMT.053.