### PR TITLE
[18.0][FIX] account_statement_import_camt: TxDtls amounts not equals to Ntry amount

### DIFF
--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -166,6 +166,13 @@ class AccountStatementImportCamtParser(models.AbstractModel):
             transaction["narration"],
             f"{_('Cheque Number')} (Refs/ChqNb)",
         )
+        self.add_value_from_node(
+            ns,
+            node,
+            ["./ns:Chrgs/ns:Rcrd/ns:Amt", "./ns:Chrgs/ns:TtlChrgsAndTaxAmt"],
+            transaction["narration"],
+            f"{_('Charges Amount')} (Chrgs/Amt)",
+        )
 
         self.add_value_from_node(
             ns, node, ["./ns:AddtlTxInf"], transaction, "payment_ref", join_str="\n"
@@ -341,9 +348,26 @@ class AccountStatementImportCamtParser(models.AbstractModel):
             yield transaction
             return
         transaction_base = transaction
+        # Make sure the sum of TxDtls amounts equals the Ntry amount.
+        # Any difference is added to the largest TxDtls amount.
+        # (might be transaction fees ...)
+        entry_amount = transaction_base["amount"]
+        details_sum = 0.0
+        largest_transaction = None
+        parsed_transactions = []
         for node in details_nodes:
             transaction = transaction_base.copy()
+            transaction["narration"] = dict(transaction_base["narration"])
             self.parse_transaction_details(ns, node, transaction)
+            if largest_transaction is None or abs(transaction["amount"]) >= abs(
+                largest_transaction["amount"]
+            ):
+                largest_transaction = transaction
+            details_sum += transaction["amount"]
+            parsed_transactions.append(transaction)
+        if largest_transaction is not None:
+            largest_transaction["amount"] += entry_amount - details_sum
+        for transaction in parsed_transactions:
             self.generate_narration(transaction)
             yield transaction
 


### PR DESCRIPTION
I found an issue where the imported bank statement lines where not correct.

Is some cases, e.g payment fees (Chrgs...), the sum of TxDtls/amt is not equals to the Ntry/Amt.

exemple 
Ntry/Amt 1526
Ntry/NtryDtls/TxDtls/Amt 1500
Ntry/NtryDtls/TxDtls/Chrgs/Rcrd/Amt 26

The issue with the current implementation is that 1526 will be lost and replaced by 1500. The statement line is then wrong by 26.

One solution would have been to look for Amt in Chrgs but I was not able to find a standard for this.

The chosen approach is to check if the sum of all  TxDtls is equals to the Ntry/Amt. If not then add the difference to the bigger TxDtls. The advantage of this is to cover other cases that might happen (other fees....) across different banks CAMT implementation.

Also add the Chrgs info to the narration.