### PR TITLE
[18.0][FIX] account_statement_import_online_paypal: handle missing key

### DIFF
--- a/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
+++ b/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
@@ -187,6 +187,18 @@ class OnlineBankStatementProviderPayPal(models.Model):
             ("paypal", "PayPal.com"),
         ]
 
+    @api.model
+    def _paypal_format_datetime(self, dt_naive_utc):
+        """Format naive UTC datetime for PayPal query params.
+
+        PayPal is picky about schema; microseconds often break requests.
+        Use RFC3339-like format with seconds and Z (UTC).
+        """
+        if not dt_naive_utc:
+            return None
+        dt_naive_utc = dt_naive_utc.replace(microsecond=0)
+        return dt_naive_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+
     def _obtain_statement_data(self, date_since, date_until):
         self.ensure_one()
         if self.service != "paypal":
@@ -372,8 +384,14 @@ class OnlineBankStatementProviderPayPal(models.Model):
 
     def _paypal_get_transaction(self, token, transaction_id, timestamp):
         self.ensure_one()
-        transaction_date_ini = (timestamp - relativedelta(seconds=1)).isoformat() + "Z"
-        transaction_date_end = (timestamp + relativedelta(seconds=1)).isoformat() + "Z"
+        # Make sure we cover the whole day to avoid PayPal "missing" some transactions
+        ts = timestamp.replace(microsecond=0)
+        transaction_date_ini = self._paypal_format_datetime(
+            ts - relativedelta(seconds=1)
+        )
+        transaction_date_end = self._paypal_format_datetime(
+            ts + relativedelta(hour=23, minute=59, second=59)
+        )
         url = (
             (self.api_base or PAYPAL_API_BASE)
             + "/v1/reporting/transactions"
@@ -416,8 +434,8 @@ class OnlineBankStatementProviderPayPal(models.Model):
                         "&page=%d"
                         % (
                             currency,
-                            interval_start.isoformat() + "Z",
-                            interval_end.isoformat() + "Z",
+                            self._paypal_format_datetime(interval_start),
+                            self._paypal_format_datetime(interval_end),
                             page,
                         )
                     )

--- a/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
+++ b/account_statement_import_online_paypal/models/online_bank_statement_provider_paypal.py
@@ -392,21 +392,21 @@ class OnlineBankStatementProviderPayPal(models.Model):
         transaction_date_end = self._paypal_format_datetime(
             ts + relativedelta(hour=23, minute=59, second=59)
         )
-        url = (
-            (self.api_base or PAYPAL_API_BASE)
-            + "/v1/reporting/transactions"
-            + (
-                f"?start_date={transaction_date_ini}"
-                f"&end_date={transaction_date_end}"
-                "&fields=all"
-            )
-        )
+        base = self.api_base or PAYPAL_API_BASE
+        params = {
+            "start_date": transaction_date_ini,
+            "end_date": transaction_date_end,
+            "fields": "all",
+        }
+        url = f"{base}/v1/reporting/transactions?{urlencode(params)}"
         data = self._paypal_retrieve(url, token)
-        transactions = data["transaction_details"]
+        transactions = data.get("transaction_details") or []
         for transaction in transactions:
-            if transaction["transaction_info"]["transaction_id"] != transaction_id:
-                continue
-            return transaction
+            if (
+                transaction.get("transaction_info", {}).get("transaction_id")
+                == transaction_id
+            ):
+                return transaction
         return None
 
     def _paypal_get_transactions(self, token, currency, since, until):
@@ -416,30 +416,22 @@ class OnlineBankStatementProviderPayPal(models.Model):
         interval_step = relativedelta(days=31)
         interval_start = since
         transactions = []
+        base = self.api_base or PAYPAL_API_BASE
         while interval_start < until:
             interval_end = min(interval_start + interval_step, until)
             page = 1
             total_pages = None
             while total_pages is None or page <= total_pages:
-                url = (
-                    (self.api_base or PAYPAL_API_BASE)
-                    + "/v1/reporting/transactions"
-                    + (
-                        "?transaction_currency=%s"
-                        "&start_date=%s"
-                        "&end_date=%s"
-                        "&fields=all"
-                        "&balance_affecting_records_only=Y"
-                        "&page_size=500"
-                        "&page=%d"
-                        % (
-                            currency,
-                            self._paypal_format_datetime(interval_start),
-                            self._paypal_format_datetime(interval_end),
-                            page,
-                        )
-                    )
-                )
+                params = {
+                    "transaction_currency": currency,
+                    "start_date": self._paypal_format_datetime(interval_start),
+                    "end_date": self._paypal_format_datetime(interval_end),
+                    "fields": "all",
+                    "balance_affecting_records_only": "Y",
+                    "page_size": 500,
+                    "page": page,
+                }
+                url = f"{base}/v1/reporting/transactions?{urlencode(params)}"
 
                 # NOTE: Workaround for INVALID_REQUEST (see ROADMAP.rst)
                 invalid_data_workaround = self.env.context.get(
@@ -450,22 +442,25 @@ class OnlineBankStatementProviderPayPal(models.Model):
                 data = self.with_context(
                     invalid_data_workaround=invalid_data_workaround,
                 )._paypal_retrieve(url, token)
-                if data.get("transaction_details"):
-                    interval_transactions = map(
-                        lambda transaction: self._paypal_preparse_transaction(
-                            transaction
-                        ),
-                        data["transaction_details"],
+                transaction_details = data.get("transaction_details") or []
+                interval_transactions = map(
+                    lambda transaction: self._paypal_preparse_transaction(transaction),
+                    transaction_details,
+                )
+                transactions += list(
+                    filter(
+                        lambda transaction: interval_start
+                        <= self._paypal_get_transaction_date(transaction)
+                        < interval_end,
+                        interval_transactions,
                     )
-                    transactions += list(
-                        filter(
-                            lambda transaction: interval_start
-                            <= self._paypal_get_transaction_date(transaction)
-                            < interval_end,
-                            interval_transactions,
-                        )
-                    )
-                total_pages = data["total_pages"]
+                )
+                total_pages = data.get("total_pages")
+                if total_pages is None:
+                    # If payload is incomplete but no error was raised,
+                    # treat as single page to avoid infinite loop.
+                    total_pages = 1
+
                 page += 1
             interval_start += interval_step
         return transactions
@@ -521,7 +516,7 @@ class OnlineBankStatementProviderPayPal(models.Model):
     def _paypal_retrieve(self, url, auth, data=None):
         try:
             with self._paypal_urlopen(url, auth, data) as response:
-                content = response.read().decode("utf-8")
+                raw = response.read().decode("utf-8")
         except HTTPError as e:
             content = json.loads(e.read().decode("utf-8"))
 
@@ -539,7 +534,20 @@ class OnlineBankStatementProviderPayPal(models.Model):
                 }
 
             raise self._paypal_decode_error(content) or e from None
-        return json.loads(content)
+
+        # Parse JSON
+        try:
+            content = json.loads(raw)
+        except Exception as exc:
+            raise UserError(
+                self.env._("Invalid JSON response from PayPal API.")
+            ) from exc
+
+        err = self._paypal_decode_error(content)
+        if err:
+            raise err
+
+        return content
 
     @api.model
     def _paypal_urlopen(self, url, auth, data=None):

--- a/account_statement_import_online_paypal/tests/test_account_statement_import_online_paypal.py
+++ b/account_statement_import_online_paypal/tests/test_account_statement_import_online_paypal.py
@@ -818,3 +818,84 @@ class TestAccountBankAccountStatementImportOnlinePayPal(common.TransactionCase):
                 "unique_import_id": f"1234567890-{self.today_timestamp}",
             },
         )
+
+    def test_retrieve_invalid_json_response(self):
+        """Cover new logic: if PayPal returns non-JSON body, raise UserError."""
+        journal = self.AccountJournal.create(
+            {
+                "name": "Bank",
+                "type": "bank",
+                "code": "BANK",
+                "currency_id": self.currency_eur.id,
+                "bank_statements_source": "online",
+                "online_bank_statement_provider": "paypal",
+            }
+        )
+        provider = journal.online_bank_statement_provider_id
+        mocked_response = UrlopenRetValMock("<html>not a json</html>", throw=False)
+        with mock.patch(
+            _provider_class + "._paypal_urlopen",
+            return_value=mocked_response,
+        ):
+            with self.assertRaisesRegex(
+                UserError, "Invalid JSON response from PayPal API"
+            ):
+                provider._paypal_retrieve("https://url", "--TOKEN--")
+
+    def test_get_transactions_missing_transaction_details(self):
+        """
+        Response without `transaction_details` must
+        not crash and should return empty list.
+        """
+        journal = self.AccountJournal.create(
+            {
+                "name": "Bank",
+                "type": "bank",
+                "code": "BANK",
+                "currency_id": self.currency_eur.id,
+                "bank_statements_source": "online",
+                "online_bank_statement_provider": "paypal",
+            }
+        )
+        provider = journal.online_bank_statement_provider_id
+        # PayPal-like error payload without `transaction_details`
+        mocked_payload = {
+            "name": "INVALID_REQUEST",
+            "message": "Request is not well-formed, syntactically "
+            "incorrect, or violates schema.",
+            # so that the page cycle ends correctly
+            "total_pages": 0,
+        }
+        since = self.now - relativedelta(hours=1)
+        until = self.now
+        with mock.patch(
+            _provider_class + "._paypal_retrieve",
+            return_value=mocked_payload,
+        ):
+            tx = provider._paypal_get_transactions("--TOKEN--", "EUR", since, until)
+        self.assertEqual(tx, [])
+
+    def test_paypal_format_datetime(self):
+        """
+        Ensure PayPal datetime formatter drops
+        microseconds and uses UTC Z format.
+        """
+        journal = self.AccountJournal.create(
+            {
+                "name": "Bank",
+                "type": "bank",
+                "code": "BANK",
+                "currency_id": self.currency_eur.id,
+                "bank_statements_source": "online",
+                "online_bank_statement_provider": "paypal",
+            }
+        )
+        provider = journal.online_bank_statement_provider_id
+        # None -> None
+        self.assertIsNone(provider._paypal_format_datetime(None))
+        # Drops microseconds + Z format
+        dt = datetime(2026, 1, 15, 11, 28, 27, 749445)  # naive UTC
+        self.assertEqual(
+            provider._paypal_format_datetime(dt),
+            "2026-01-15T11:28:27Z",
+        )


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/bank-statement-import/pull/889

- Fixes a crash when pulling PayPal online bank statements: PayPal can return a response without `transaction_details`, which currently breaks the pull with a server error (`KeyError: 'transaction_details'`);
- Improve error handling and return clear UserError messages;
- Ensure PayPal datetime formatting is schema-safe (no microseconds);
- Writе tests to cover the new logic and keep coverage green.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa