### PR TITLE
[17.0][FIX] account_statement_import_file: stable Import button xpath

### DIFF
--- a/account_statement_import_file/views/account_journal.xml
+++ b/account_statement_import_file/views/account_journal.xml
@@ -2,6 +2,7 @@
 <!--
   Copyright 2004-2020 Odoo S.A.
   Copyright 2020 Akretion France (http://www.akretion.com/)
+  Copyright 2026 QubiQ - Pol Reig <pol.reig@qubiq.es>
   @author: Alexis de Lattre <alexis.delattre@akretion.com>
   Licence LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0).
 -->
@@ -11,10 +12,7 @@
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.account_journal_dashboard_kanban_view" />
         <field name="arch" type="xml">
-            <xpath
-                expr='//button[@name="action_configure_bank_journal"]/..'
-                position='before'
-            >
+            <xpath expr="//div[@id='transactions']" position="before">
                 <t t-if="dashboard.bank_statements_source == 'file_import_oca'">
                     <button
                         name="import_account_statement"


### PR DESCRIPTION
## Description

On Odoo **Enterprise**, a recent change in `account_online_synchronization` wraps the journal dashboard **Connect** button in a new `t-if="dashboard.show_bank_connect"`.

This module used:

```xml
//button[@name="action_configure_bank_journal"]/..
```

After that Enterprise replace, the parent of the Connect button is no longer the core `t-if` on `bank_statements_source in ['undefined', 'online_sync']`, but the new Enterprise wrapper **inside** it. The OCA **Import (OCA)** button is therefore inserted under a condition that contradicts `file_import_oca`, so it never renders.

Community is unaffected (no Enterprise replace). The menu link **Import Statement (OCA)** (second xpath) still works; only the primary dashboard button is lost.

## Fix

Anchor to the stable core sibling `div#transactions` (present in Odoo 17.0 `account` journal kanban), which Enterprise does not wrap:

```xml
<xpath expr="//div[@id='transactions']" position="before">
```

## Why this was not reported before

- Only breaks with Enterprise + updated `account_online_synchronization` source (no module version bump on Enterprise side).
- OCA CI runs Community only.
- The xpath still resolves (no install error); the button is simply never visible.
- Users can still import via the journal ⋮ menu.

## Note on 18.0+

Odoo 18 redesigned the journal dashboard (`div#transactions` no longer exists). This PR targets **17.0** only. A separate change is needed if the same regression appears on 18.0.

## Checklist

- [x] No manual manifest version bump (bot on merge)
- [x] Copyright only in the touched XML header (no CONTRIBUTORS churn)
- [x] pre-commit clean
- [ ] Manual check on Enterprise with `bank_statements_source = file_import_oca`

@alexis-via @pedrobaeza