### PR TITLE
[T3354] FIX account_statement_import_camt54: match journal on NtryRef…

### DIFF
--- a/account_statement_import_camt54/models/parser.py
+++ b/account_statement_import_camt54/models/parser.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import re
+
 from odoo import models
 from odoo.exceptions import UserError
 
@@ -99,3 +101,25 @@ class CamtParser(models.AbstractModel):
             "ref",
         )
         return True
+
+    def parse_statement(self, ns, node):
+        """In case of a camt.054 file, the QR-IBAN to be used as the
+        account_number is found in the entry's own reference rather than
+        the account-level IBAN."""
+        result = super().parse_statement(ns, node)
+        re_camt_version = re.compile(
+            r"(^urn:iso:std:iso:20022:tech:xsd:camt.054." r"|^ISO:camt.054.)"
+        )
+        if re_camt_version.search(ns):
+            self.add_value_from_node(
+                ns,
+                node,
+                [
+                    "./ns:Ntry[1]/ns:NtryRef",
+                    "./ns:Acct/ns:Id/ns:IBAN",
+                    "./ns:Acct/ns:Id/ns:Othr/ns:Id",
+                ],
+                result,
+                "account_number",
+            )
+        return result

--- a/account_statement_import_camt54/tests/samples/test-camt054-qrr.xml
+++ b/account_statement_import_camt54/tests/samples/test-camt054-qrr.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.054.001.04 camt.054.001.04.xsd">
+  <BkToCstmrDbtCdtNtfctn>
+    <GrpHdr>
+      <MsgId>M/00000000000/CA</MsgId>
+      <CreDtTm>2026-08-03T12:13:14+02:00</CreDtTm>
+      <AddtlInf>SPS/1.7/PROD</AddtlInf>
+    </GrpHdr>
+    <Ntfctn>
+      <Id>M/00000000000/CA</Id>
+      <ElctrncSeqNb>1</ElctrncSeqNb>
+      <CreDtTm>2026-08-03T12:13:14+02:00</CreDtTm>
+      <Acct>
+        <Id>
+          <IBAN>CH0000000000000000001</IBAN>
+        </Id>
+        <Ownr>
+          <Nm>TEST COMPANY</Nm>
+        </Ownr>
+        <Svcr>
+          <FinInstnId>
+            <Nm>Test Bank</Nm>
+          </FinInstnId>
+        </Svcr>
+      </Acct>
+      <Ntry>
+        <NtryRef>CH0000000000000000002</NtryRef>
+        <Amt Ccy="CHF">184</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>BOOK</Sts>
+        <BookgDt>
+          <Dt>2026-08-03</Dt>
+        </BookgDt>
+        <ValDt>
+          <Dt>2026-08-03</Dt>
+        </ValDt>
+        <AcctSvcrRef>00000000000</AcctSvcrRef>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>VCOM</SubFmlyCd>
+            </Fmly>
+          </Domn>
+          <Prtry>
+            <Cd>1004</Cd>
+          </Prtry>
+        </BkTxCd>
+        <NtryDtls>
+          <Btch>
+            <NbOfTxs>2</NbOfTxs>
+          </Btch>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>A000000000000001</AcctSvcrRef>
+            </Refs>
+            <Amt Ccy="CHF">42</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <BkTxCd>
+              <Domn>
+                <Cd>PMNT</Cd>
+                <Fmly>
+                  <Cd>RCDT</Cd>
+                  <SubFmlyCd>VCOM</SubFmlyCd>
+                </Fmly>
+              </Domn>
+              <Prtry>
+                <Cd>1004</Cd>
+              </Prtry>
+            </BkTxCd>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Test Donor One</Nm>
+                <PstlAdr>
+                  <StrtNm>Test Street</StrtNm>
+                  <BldgNb>1</BldgNb>
+                  <PstCd>1000</PstCd>
+                  <TwnNm>Test Town</TwnNm>
+                  <Ctry>CH</Ctry>
+                </PstlAdr>
+              </Dbtr>
+              <DbtrAcct>
+                <Id>
+                  <IBAN>CH0000000000000000101</IBAN>
+                </Id>
+              </DbtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <Nm>Test Debtor Bank One</Nm>
+                </FinInstnId>
+              </DbtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Prtry>QRR</Prtry>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>000000000000000000000000001</Ref>
+                </CdtrRefInf>
+              </Strd>
+            </RmtInf>
+          </TxDtls>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>A000000000000002</AcctSvcrRef>
+            </Refs>
+            <Amt Ccy="CHF">142</Amt>
+            <CdtDbtInd>CRDT</CdtDbtInd>
+            <BkTxCd>
+              <Domn>
+                <Cd>PMNT</Cd>
+                <Fmly>
+                  <Cd>RCDT</Cd>
+                  <SubFmlyCd>VCOM</SubFmlyCd>
+                </Fmly>
+              </Domn>
+              <Prtry>
+                <Cd>1004</Cd>
+              </Prtry>
+            </BkTxCd>
+            <RltdPties>
+              <Dbtr>
+                <Nm>Test Donor Two</Nm>
+                <PstlAdr>
+                  <StrtNm>Test Street</StrtNm>
+                  <BldgNb>2</BldgNb>
+                  <PstCd>2000</PstCd>
+                  <TwnNm>Test Town</TwnNm>
+                  <Ctry>CH</Ctry>
+                </PstlAdr>
+              </Dbtr>
+              <DbtrAcct>
+                <Id>
+                  <IBAN>CH0000000000000000102</IBAN>
+                </Id>
+              </DbtrAcct>
+            </RltdPties>
+            <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <Nm>Test Debtor Bank Two</Nm>
+                </FinInstnId>
+              </DbtrAgt>
+            </RltdAgts>
+            <RmtInf>
+              <Strd>
+                <CdtrRefInf>
+                  <Tp>
+                    <CdOrPrtry>
+                      <Prtry>QRR</Prtry>
+                    </CdOrPrtry>
+                  </Tp>
+                  <Ref>000000000000000000000000002</Ref>
+                </CdtrRefInf>
+                <AddtlRmtInf>Test remittance info</AddtlRmtInf>
+              </Strd>
+            </RmtInf>
+          </TxDtls>
+        </NtryDtls>
+      </Ntry>
+    </Ntfctn>
+  </BkToCstmrDbtCdtNtfctn>
+</Document>

--- a/account_statement_import_camt54/tests/test_statement.py
+++ b/account_statement_import_camt54/tests/test_statement.py
@@ -15,7 +15,9 @@ class TestGenerateBankStatement(TransactionCase):
         eur_currency.write({"active": True})
         bank = cls.env["res.partner.bank"].create(
             {
-                "acc_number": "NL77ABNA0574908765",
+                # test-camt054's Ntry/NtryRef, not its Acct/IBAN: for camt.054
+                # files the parser now matches the journal on NtryRef.
+                "acc_number": "NL0000000000000000000",
                 "partner_id": cls.env.ref("base.main_partner").id,
                 "company_id": cls.env.ref("base.main_company").id,
                 "bank_id": cls.env.ref("base.res_bank_1").id,
@@ -71,3 +73,69 @@ class TestGenerateBankStatement(TransactionCase):
         lines = self._load_statement()
         self.assertEqual(len(lines), 1)
         self.assertAlmostEqual(sum(lines.mapped("amount")), 5.0)
+
+    def test_statement_import_camt054_matches_journal_on_ntryref(self):
+        """A camt.054 QR-bill notification must pick the journal whose
+        account matches Ntry/NtryRef (the QR-IBAN), not the notification's
+        own Acct/IBAN (the regular account both journals share)."""
+        chf_currency = self.env.ref("base.CHF")
+        chf_currency.write({"active": True})
+        physical_account_bank = self.env["res.partner.bank"].create(
+            {
+                "acc_number": "CH0000000000000000001",
+                "partner_id": self.env.ref("base.main_partner").id,
+                "company_id": self.env.ref("base.main_company").id,
+                "bank_id": self.env.ref("base.res_bank_1").id,
+            }
+        )
+        self.env["account.journal"].create(
+            {
+                "name": "Test physical account journal (camt054)",
+                "code": "TPH54",
+                "type": "bank",
+                "bank_account_id": physical_account_bank.id,
+                "currency_id": chf_currency.id,
+            }
+        )
+        qrr_account_bank = self.env["res.partner.bank"].create(
+            {
+                "acc_number": "CH0000000000000000002",
+                "partner_id": self.env.ref("base.main_partner").id,
+                "company_id": self.env.ref("base.main_company").id,
+                "bank_id": self.env.ref("base.res_bank_1").id,
+            }
+        )
+        qrr_journal = self.env["account.journal"].create(
+            {
+                "name": "Test QRR journal (camt054)",
+                "code": "TQR54",
+                "type": "bank",
+                "bank_account_id": qrr_account_bank.id,
+                "currency_id": chf_currency.id,
+            }
+        )
+
+        testfile = file_path(
+            "account_statement_import_camt54/tests/samples/test-camt054-qrr.xml"
+        )
+        with open(testfile, "rb") as datafile:
+            camt_file = base64.b64encode(datafile.read())
+            action = (
+                self.env["account.statement.import"]
+                .create(
+                    {
+                        "statement_filename": "test-camt054-qrr.xml",
+                        "statement_file": camt_file,
+                    }
+                )
+                .import_file_button()
+            )
+
+        statement = self.env["account.bank.statement"].browse(action["domain"][0][2])
+        self.assertEqual(
+            statement.journal_id,
+            qrr_journal,
+            "Statement should have been imported into the QRR journal, "
+            f"got {statement.journal_id.display_name!r}",
+        )
+        self.assertAlmostEqual(sum(statement.line_ids.mapped("amount")), 184.0)


### PR DESCRIPTION
# T3354 — Fix failing quality test: Income processing: import CAMT files

## Context / Problem Statement

The import of CAMT files chooses the destination journal automatically from
the account number found in the XML. It always reads it from
`Acct/Id/IBAN` — but for **camt.054** files, the account should instead be
read from `Ntry/NtryRef`, per the v14 branch:
https://github.com/CompassionCH/bank-statement-import/blob/11f86e402efc2c40ef59a3447b53b05f636da56f/account_statement_import_camt54/models/parser.py#L111

## Background: why Acct/IBAN and Ntry/NtryRef differ

Swiss banks issue a **QR-IBAN** — a special IBAN reserved for scanning
QR-bills — in addition to a company's regular IBAN, both pointing at the
same physical account. A camt.054 QR-bill batch reports the QR-IBAN via
`Ntry/NtryRef`, while the notification's own `Acct/IBAN` still shows the
regular IBAN. Compassion has two separate Odoo journals for the same
physical account ("Raiffeisen Current Account CHF" vs "QRR Raiffeisen"),
matched by whichever value ends up as the file's `account_number`.

## Root cause

`account_statement_import_camt54/models/parser.py`'s `CamtParser` (v18) had
no `parse_statement()` override at all — it inherited the base
`account_statement_import_camt` parser's version unchanged, which always
sets `account_number` from `Acct/Id/IBAN` regardless of camt version. The
v14 branch already has this override; it was simply never ported to v18.

## What changed

- `models/parser.py`: added `parse_statement()` — for camt.054 files only,
  prefer `Ntry[1]/NtryRef` over `Acct/Id/IBAN` when setting
  `account_number` (falls back to IBAN if `NtryRef` is absent). Ported
  directly from the v14 branch.

## How to test manually

1. Get a camt.054 file where the notification's `Acct/IBAN` is the regular
   account and `Ntry/NtryRef` is the QR-IBAN (e.g. the file attached to the
   ticket).
2. Accounting → import the file via the statement-import wizard, letting it
   auto-detect the journal (don't pre-select one).
3. Confirm the resulting bank statement lands in the QRR-dedicated journal
   ("QRR Raiffeisen"), not the regular account's journal ("Raiffeisen
   Current Account CHF").