### PR TITLE
[18.0][FIX] account_statement_import_online_plaid: Look back 10 days for scheduled syncs

### DIFF
--- a/account_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_statement_import_online/models/online_bank_statement_provider.py
@@ -490,6 +490,23 @@ class OnlineBankStatementProvider(models.Model):
         elif self.interval_type == "weeks":
             return relativedelta(weeks=self.interval_number)
 
+    def _get_scheduled_pull_lookback(self):
+        """
+        Return the minimum period that scheduled pulls should look back from now.
+        For example, to handle transactions that take a while to settle, or for
+        providers where their data feed is delayed.
+        """
+        self.ensure_one()
+        return relativedelta()
+
+    def _get_scheduled_pull_date_since(self, date_since):
+        """Apply the provider's minimum lookback to a scheduled start date."""
+        self.ensure_one()
+        lookback = self._get_scheduled_pull_lookback()
+        if not lookback:
+            return date_since
+        return min(date_since, fields.Datetime.now() - lookback)
+
     @api.model
     def _scheduled_pull(self):
         _logger.info(_("Scheduled pull of online bank statements..."))
@@ -510,6 +527,7 @@ class OnlineBankStatementProvider(models.Model):
                     if provider.last_successful_run
                     else (provider.next_run - provider._get_next_run_period())
                 )
+                date_since = provider._get_scheduled_pull_date_since(date_since)
                 date_until = provider.next_run
                 provider._pull(date_since, date_until)
         _logger.info(_("Scheduled pull of online bank statements complete."))

--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -93,6 +93,35 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
         self.provider.with_context(step={"hours": 8})._scheduled_pull()
         self._getExpectedStatements(1)
 
+    def test_scheduled_pull_has_no_default_lookback(self):
+        date_since = self.now - relativedelta(hours=1)
+        self.assertFalse(self.provider._get_scheduled_pull_lookback())
+        self.assertEqual(
+            self.provider._get_scheduled_pull_date_since(date_since), date_since
+        )
+
+    def test_scheduled_pull_lookback(self):
+        now = datetime(2026, 12, 10, 12)
+        recent_date_since = now - relativedelta(hours=1)
+        old_date_since = now - relativedelta(days=30)
+
+        with (
+            mock.patch.object(
+                type(self.provider),
+                "_get_scheduled_pull_lookback",
+                return_value=relativedelta(days=14),
+            ),
+            mock.patch.object(fields.Datetime, "now", return_value=now),
+        ):
+            self.assertEqual(
+                self.provider._get_scheduled_pull_date_since(recent_date_since),
+                now - relativedelta(days=14),
+            )
+            self.assertEqual(
+                self.provider._get_scheduled_pull_date_since(old_date_since),
+                old_date_since,
+            )
+
     def test_pull_skip_duplicates_by_unique_import_id(self):
         self.provider.statement_creation_mode = "weekly"
         # Get for two weeks of data.

--- a/account_statement_import_online_plaid/models/online_bank_statement_provider_plaid.py
+++ b/account_statement_import_online_plaid/models/online_bank_statement_provider_plaid.py
@@ -1,5 +1,7 @@
 # Copyright 2024 Binhex - Adasat Torres de León.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from dateutil.relativedelta import relativedelta
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -40,6 +42,15 @@ class OnlineBankStatementProvider(models.Model):
         if self.service != "plaid":
             return super()._obtain_statement_data(date_since, date_until)
         return self._plaid_retrieve_data(date_since, date_until), {}
+
+    def _get_scheduled_pull_lookback(self):
+        if self.service == "plaid":
+            # Look back 10 days for scheduled syncs. This is because:
+            # 1. Transactions can take a few days to clear.
+            # 2. Some bank data is delayed, for example data from Wells Fargo
+            #    can take 24-48 hours to become available in Plaid.
+            return relativedelta(days=10)
+        return super()._get_scheduled_pull_lookback()
 
     @api.model
     def _get_available_services(self):


### PR DESCRIPTION
Currently, bank statements are synchronized by using a date range.  An issue with this is that transactions can appear in the past, for example if they a while to clear. Because of this, I was missing several transactions and had to manually sync the date range to pull them.

Changing the statement interval to "month" works around it somewhat. Even when not using statements, it still changes the scheduled pulls to request transactions for the whole month, so for example a scheduled pull on 15th August will pull all transactions from 1st August until 31st August. 

However, transactions made at the end of the month that aren't cleared until the next month still have issues with this. for example, a transaction on 30th July that doesn't settle until 3rd August would still be missing. It's not just pending transactions that cause issues though. Plaid's data can be delayed too. Wells Fargo is notorious for this... Their data can take up to 48 hours to sync into Plaid, so even if a transaction settles on 30th July, it might not be available via Plaid's API until the first week of August

This PR adds the ability to configure a minimum lookback window per provider, only used for scheduled pulls. It clamps the `date_since`  at `MIN(date_since, NOW - lookback)`. For now, I've hardcoded 10 days just for the Plaid provider.

Fixes #883
References #987