### PR TITLE
[18.0][IMP] account_statement_import_file: Cash + Credit card journal compatibility

### DIFF
--- a/account_statement_import_file/views/account_journal.xml
+++ b/account_statement_import_file/views/account_journal.xml
@@ -26,7 +26,10 @@
                 </t>
             </xpath>
             <xpath expr='//div[@name="bank_customer_payment"]' position="before">
-                <div t-if="journal_type == 'bank'" groups="account.group_account_user">
+                <div
+                    t-if="journal_type == 'bank' or journal_type == 'cash' or journal_type == 'credit'"
+                    groups="account.group_account_user"
+                >
                     <a
                         type="object"
                         name="import_account_statement"


### PR DESCRIPTION
Cash + Credit card journal compatibility

It is possible to create bank statements in cash/credit carfd journals; therefore, it makes sense that statements can also be imported

Please @pedrobaeza and @Andrii9090-tecnativa can you review it?

@Tecnativa TT64240