### PR TITLE
[18.0][FIX] account_statement_import_online_stripe: Include payment intent ID in default label

### DIFF
--- a/account_statement_import_online_stripe/__manifest__.py
+++ b/account_statement_import_online_stripe/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Online Bank Statements: Stripe",
-    "version": "18.0.1.0.2",
+    "version": "18.0.1.1.0",
     "author": "Akiles, Tecnativa, Odoo Community Association (OCA)",
     "maintainers": ["juancarlosonate-tecnativa"],
     "website": "https://github.com/OCA/bank-statement-import",

--- a/account_statement_import_online_stripe/__manifest__.py
+++ b/account_statement_import_online_stripe/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Online Bank Statements: Stripe",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.0.2",
     "author": "Akiles, Tecnativa, Odoo Community Association (OCA)",
     "maintainers": ["juancarlosonate-tecnativa"],
     "website": "https://github.com/OCA/bank-statement-import",

--- a/account_statement_import_online_stripe/migrations/18.0.1.1.0/post-migration.py
+++ b/account_statement_import_online_stripe/migrations/18.0.1.1.0/post-migration.py
@@ -1,0 +1,21 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+OLD_STRIPE_LABEL = (
+    "stripe {source.metadata.invoice_number} {source.object} "
+    "{source.id} {source.payment_method_details.type}"
+)
+NEW_STRIPE_LABEL = (
+    "stripe {source.metadata.invoice_number} {source.payment_intent} "
+    "{source.object} {source.id} {source.payment_method_details.type}"
+)
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE online_bank_statement_provider
+        SET stripe_label = %s
+        WHERE stripe_label = %s
+        """,
+        (NEW_STRIPE_LABEL, OLD_STRIPE_LABEL),
+    )

--- a/account_statement_import_online_stripe/models/online_bank_statement_provider_stripe.py
+++ b/account_statement_import_online_stripe/models/online_bank_statement_provider_stripe.py
@@ -20,8 +20,8 @@ class OnlineBankStatementProviderStripe(models.Model):
 
     stripe_label = fields.Char(
         default=(
-            "stripe {source.metadata.invoice_number} {source.object} "
-            "{source.id} {source.payment_method_details.type}"
+            "stripe {source.metadata.invoice_number} {source.payment_intent} "
+            "{source.object} {source.id} {source.payment_method_details.type}"
         )
     )
     stripe_note = fields.Char()

--- a/account_statement_import_online_stripe/tests/__init__.py
+++ b/account_statement_import_online_stripe/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import test_migration
 from . import test_online_bank_statement_provider_stripe

--- a/account_statement_import_online_stripe/tests/test_migration.py
+++ b/account_statement_import_online_stripe/tests/test_migration.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from runpy import run_path
+
+from odoo.addons.base.tests.common import BaseCommon
+
+
+class TestStripeLabelMigration(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        journal = cls.env["account.journal"].create(
+            {
+                "name": "Bank",
+                "type": "bank",
+                "code": "BANK",
+                "bank_statements_source": "online",
+            }
+        )
+        cls.provider = cls.env["online.bank.statement.provider"].create(
+            {
+                "service": "stripe",
+                "journal_id": journal.id,
+            }
+        )
+
+    def test_migration_updates_only_default_stripe_label(self):
+        old_label = (
+            "stripe {source.metadata.invoice_number} {source.object} "
+            "{source.id} {source.payment_method_details.type}"
+        )
+        new_label = (
+            "stripe {source.metadata.invoice_number} {source.payment_intent} "
+            "{source.object} {source.id} {source.payment_method_details.type}"
+        )
+        migration_path = (
+            Path(__file__).parents[1]
+            / "migrations"
+            / "18.0.1.1.0"
+            / "post-migration.py"
+        )
+        migrate = run_path(str(migration_path))["migrate"]
+
+        self.provider.stripe_label = old_label
+        self.provider.flush_recordset(["stripe_label"])
+        migrate(self.env.cr, "18.0.1.0.1")
+        self.provider.invalidate_recordset(["stripe_label"])
+        self.assertEqual(self.provider.stripe_label, new_label)
+
+        custom_label = "Custom Stripe label"
+        self.provider.stripe_label = custom_label
+        self.provider.flush_recordset(["stripe_label"])
+        migrate(self.env.cr, "18.0.1.0.1")
+        self.provider.invalidate_recordset(["stripe_label"])
+        self.assertEqual(self.provider.stripe_label, custom_label)

--- a/account_statement_import_online_stripe/tests/test_online_bank_statement_provider_stripe.py
+++ b/account_statement_import_online_stripe/tests/test_online_bank_statement_provider_stripe.py
@@ -43,6 +43,7 @@ class TestOnlineBankStatementProviderStripe(BaseCommon):
                         "id": "ch_123",
                         "object": "charge",
                         "metadata": {"invoice_number": "INV-001"},
+                        "payment_intent": "pi_123",
                         "payment_method_details": {"type": "card"},
                     },
                 },
@@ -58,6 +59,7 @@ class TestOnlineBankStatementProviderStripe(BaseCommon):
                         "id": "ch_456",
                         "object": "charge",
                         "metadata": {"invoice_number": "INV-002"},
+                        "payment_intent": "pi_456",
                         "payment_method_details": {"type": "card"},
                     },
                 },
@@ -79,7 +81,8 @@ class TestOnlineBankStatementProviderStripe(BaseCommon):
             self.assertEqual(statement_data[0]["unique_import_id"], "txn_123")
             self.assertEqual(statement_data[0]["ref"], "INV-001")
             self.assertEqual(
-                statement_data[0]["payment_ref"], "stripe INV-001 charge ch_123 card"
+                statement_data[0]["payment_ref"],
+                "stripe INV-001 pi_123 charge ch_123 card",
             )
             self.assertEqual(statement_data[0]["narration"], "Custom Note charge")
             self.assertEqual(statement_data[1]["amount"], -1.0)
@@ -94,7 +97,8 @@ class TestOnlineBankStatementProviderStripe(BaseCommon):
             self.assertEqual(statement_data[2]["unique_import_id"], "txn_456")
             self.assertEqual(statement_data[2]["ref"], "INV-002")
             self.assertEqual(
-                statement_data[2]["payment_ref"], "stripe INV-002 charge ch_456 card"
+                statement_data[2]["payment_ref"],
+                "stripe INV-002 pi_456 charge ch_456 card",
             )
             self.assertEqual(statement_data[2]["narration"], "Custom Note charge")
             self.assertEqual(statement_data[3]["amount"], -2.0)


### PR DESCRIPTION
The payment intent ID is needed to reconcile invoice payments with the synced line items

Example reconciliation model:
```xml
<record id="reconcile_model_stripe_payment_intent" model="account.reconcile.model">
    <field name="name">Stripe PaymentIntent Match</field>
    <field name="sequence">0</field>
    <field name="rule_type">invoice_matching</field>
    <field name="auto_reconcile" eval="True" />
    <field name="unique_matching" eval="True" />
    <field name="match_nature">amount_received</field>
    <field name="match_label">match_regex</field>
    <field
        name="match_label_param"
    >^stripe\b(?=.*\bpi_[0-9a-z]+\b)(?=.*\b(?:charge|payment)\b).*$</field>
    <field name="match_same_currency" eval="True" />
    <field name="match_partner" eval="False" />
    <field name="match_text_location_label" eval="True" />
    <field name="match_text_location_note" eval="False" />
    <field name="match_text_location_reference" eval="False" />
    <field name="allow_payment_tolerance" eval="True" />
    <field name="payment_tolerance_param">0</field>
**</record>**
```