### PR TITLE
[19.0][FIX] account_statement_import_sheet_file_xlsx: keep numeric cells native

### DIFF
--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -394,6 +394,23 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             1234.56,
         )
 
+    def test_int_inputs(self):
+        # Sheet backends hand over native ints for whole values. Parsing them
+        # as text made the "no decimal separator" branch insert a decimal point
+        # based on the currency precision, turning 1234 into 12.34.
+        self.assertEqual(
+            self.parser._parse_decimal(1234, self.mock_mapping_none_none),
+            1234,
+        )
+        self.assertEqual(
+            self.parser._parse_decimal(-1234, self.mock_mapping_none_none),
+            -1234,
+        )
+        self.assertEqual(
+            self.parser._parse_decimal(1234, self.mock_mapping_comma_dot),
+            1234,
+        )
+
     @mute_logger(
         "odoo.addons.account_statement_import_sheet_file.models."
         "account_statement_import"

--- a/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
@@ -401,8 +401,10 @@ class AccountStatementImportSheetParser(models.TransientModel):
     def _parse_decimal(self, value, mapping):
         if isinstance(value, Decimal):
             return float(value)
-        elif isinstance(value, float):
-            return value
+        elif isinstance(value, int | float) and not isinstance(value, bool):
+            # Sheet backends hand over native numbers (openpyxl returns int for
+            # whole values); they carry no separators to interpret.
+            return float(value)
         thousands, decimal = mapping._get_float_separators()
         # Remove all characters except digits, thousands separator,
         # decimal separator, and signs

--- a/account_statement_import_sheet_file_xlsx/tests/test_account_statement_import_sheet_file_xlsx.py
+++ b/account_statement_import_sheet_file_xlsx/tests/test_account_statement_import_sheet_file_xlsx.py
@@ -4,7 +4,12 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from base64 import b64encode
+from datetime import datetime
+from io import BytesIO
 from os import path
+
+import openpyxl
 
 from odoo.exceptions import UserError
 from odoo.tools import mute_logger
@@ -26,6 +31,62 @@ class TestAccountStatementImportSheetFileXlsx(
         statement = self.AccountBankStatement.search(self.statement_domain)
         self.assertEqual(len(statement), 1)
         self.assertEqual(len(statement.line_ids), 2)
+
+    def test_import_xlsx_numeric_amounts_with_comma_decimal_sep(self):
+        """Numeric cells must not be reinterpreted through the mapping seps.
+
+        Amounts stored as numbers carry no separators: the sheet only holds a
+        display format, which never reaches the parser. Rendering them as text
+        printed a dot decimal, so a mapping set to a comma decimal separator
+        dropped it and shifted the amount by a factor of 10 or 100 depending on
+        how many decimals the value had.
+        """
+        self.sample_statement_map.write(
+            {
+                "float_thousands_sep": "none",
+                "float_decimal_sep": "comma",
+                "original_currency_column": None,
+                "original_amount_column": None,
+                "partner_name_column": None,
+                "bank_account_column": None,
+                "reference_column": "Reference",
+            }
+        )
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        sheet.append(["Date", "Label", "Reference", "Amount"])
+        # Amounts as native numbers, with a display format that shows a comma
+        # decimal separator -- exactly what the mapping is configured for. The
+        # reference is numeric too, to cover a non-amount column that stops
+        # being handed over as text.
+        for label, reference, amount in [
+            ("TWO DECIMALS", 26182, 1234.56),
+            ("ONE DECIMAL", 289400, 78.9),
+            ("NO DECIMALS", 304102, 100),
+        ]:
+            sheet.append([datetime(2026, 7, 1), label, reference, amount])
+            sheet.cell(row=sheet.max_row, column=4).number_format = "#.##0,00"
+        buffer = BytesIO()
+        workbook.save(buffer)
+        wizard = self.AccountStatementImport.with_context(
+            journal_id=self.journal.id, account_statement_import_sheet_file_test=True
+        ).create(
+            {
+                "statement_filename": "numeric_amounts.xlsx",
+                "statement_file": b64encode(buffer.getvalue()),
+                "sheet_mapping_id": self.sample_statement_map.id,
+            }
+        )
+        wizard.import_file_button()
+        statement = self.AccountBankStatement.search(self.statement_domain)
+        self.assertEqual(len(statement), 1)
+        self.assertEqual(len(statement.line_ids), 3)
+        self.assertEqual(
+            sorted(statement.line_ids.mapped("amount")), [78.9, 100.0, 1234.56]
+        )
+        self.assertEqual(
+            sorted(statement.line_ids.mapped("ref")), ["26182", "289400", "304102"]
+        )
 
     def test_import_empty_xlsx_file(self):
         wizard = self._get_import_wizard("fixtures/empty_statement_en.xlsx")

--- a/account_statement_import_sheet_file_xlsx/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file_xlsx/wizard/account_statement_import_sheet_parser.py
@@ -82,6 +82,13 @@ class AccountStatementImportSheetParser(models.TransientModel):
                 cell_value = xlsx.cell(row=row, column=col_index).value
                 if isinstance(cell_value, datetime):
                     cell_value = cell_value.strftime(mapping.timestamp_format)
-                values.append(str(cell_value))
+                elif isinstance(cell_value, bool) or not isinstance(
+                    cell_value, int | float
+                ):
+                    # Keep numbers native: stringifying them here would render
+                    # the decimal point with Python notation, which no longer
+                    # matches the separators configured in the mapping.
+                    cell_value = str(cell_value)
+                values.append(cell_value)
             parsed_rows.append(values)
         return parsed_rows


### PR DESCRIPTION
## Problem

When an XLSX stores amounts as numbers and the mapping is configured with a
comma decimal separator, amounts are imported multiplied by 10 or 100, silently
and with nothing in the log.

`_get_xlsx_row_values` calls `str()` on every cell value. openpyxl already
returned the native number — the comma the user sees in the sheet is a
`number_format`, presentation only, which never travels with the value. `str()`
renders the float back to text in Python notation: dot decimal separator,
trailing zeros dropped. `_parse_decimal` then strips everything that is not the
configured separator, so with a comma decimal separator the dot disappears and
the cents become units.

The factor is not constant. Because `str()` drops trailing zeros, it depends on
how many decimals survive per value: no decimals ×1, one ×10, two ×100. A single
statement comes in with the three mixed, so there is no multiple that can be
applied afterwards to correct it — the file has to be re-imported.

The xls backend never had this problem: xlrd returns the native number, and
`_parse_decimal` short-circuits floats before reaching the separator logic.

## Fix

- `account_statement_import_sheet_file_xlsx`: only stringify cell values that
  are not numbers. Bools and empty cells keep their previous rendering, so
  nothing else changes.
- `account_statement_import_sheet_file`: `_parse_decimal` short-circuits `int`
  as well as `float`. openpyxl hands over `int` for whole values, and letting
  one reach the `re.sub` raises `TypeError`.

## Tests

Both added tests fail on 19.0 without the fix:

- `test_import_xlsx_numeric_amounts_with_comma_decimal_sep` builds a workbook
  with numeric amounts of two, one and zero decimals plus a numeric reference
  column, and imports it with a comma decimal separator mapping. Without the fix
  it yields `[100.0, 789.0, 123456.0]` instead of `[78.9, 100.0, 1234.56]`.
- `test_int_inputs` covers native ints reaching `_parse_decimal`. Without the
  fix the call raises `TypeError`; with a mapping that has no decimal separator,
  reading an int as text also inserted a decimal point based on the currency
  precision (1234 → 12.34).

Full suite of the three `sheet_file` modules: 27 passed.

## Note

`_parse_decimal` is also touched by the open #969, which adds a `str()` guard a
couple of lines below. The two are compatible — the early return added here
happens first — but whichever lands second will need a trivial rebase.

**video**
https://drive.google.com/file/d/1VLF_mnXinmm0-DOHpN4tF6BLC4QFZh6p/view