### PR TITLE
[19.0][IMP] account_statement_import_sheet_file: refuse an unconfigured decimal mark

### DIFF
--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -394,6 +394,23 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             1234.56,
         )
 
+    def test_int_inputs(self):
+        # Sheet backends hand over native ints for whole values. Parsing them
+        # as text made the "no decimal separator" branch insert a decimal point
+        # based on the currency precision, turning 1234 into 12.34.
+        self.assertEqual(
+            self.parser._parse_decimal(1234, self.mock_mapping_none_none),
+            1234,
+        )
+        self.assertEqual(
+            self.parser._parse_decimal(-1234, self.mock_mapping_none_none),
+            -1234,
+        )
+        self.assertEqual(
+            self.parser._parse_decimal(1234, self.mock_mapping_comma_dot),
+            1234,
+        )
+
     @mute_logger(
         "odoo.addons.account_statement_import_sheet_file.models."
         "account_statement_import"

--- a/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
+++ b/account_statement_import_sheet_file/tests/test_account_statement_import_sheet_file.py
@@ -68,6 +68,8 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
         cls.mock_mapping_dot_comma._get_float_separators.return_value = (".", ",")
         cls.mock_mapping_none_none = Mock()
         cls.mock_mapping_none_none._get_float_separators.return_value = ("", "")
+        cls.mock_mapping_none_comma = Mock()
+        cls.mock_mapping_none_comma._get_float_separators.return_value = ("", ",")
         cls.journal = cls.AccountJournal.create(
             {
                 "name": "Bank",
@@ -393,6 +395,30 @@ class TestAccountStatementImportSheetFile(common.TransactionCase):
             self.parser._parse_decimal(Decimal("1234.56"), self.mock_mapping_comma_dot),
             1234.56,
         )
+
+    def test_decimal_mark_not_in_mapping(self):
+        # A separator followed by fewer than three digits cannot be a thousands
+        # group, so it is a decimal mark. Stripping it as noise would multiply
+        # the amount, so the import refuses it instead.
+        for value in ["31.24", "-41.94", "460763013.7", "31.24 USD"]:
+            with self.subTest(value=value), self.assertRaises(UserError):
+                self.parser._parse_decimal(value, self.mock_mapping_none_comma)
+
+    def test_decimal_mark_thousands_group_is_allowed(self):
+        # Three digits after the separator is a well-formed thousands group:
+        # ambiguous at worst, so it keeps being read as the mapping says.
+        for value, expected in [
+            ("1.234", 1234),
+            ("1.234.567", 1234567),
+            ("100.000", 100000),
+            ("-41,94", -41.94),
+            ("", 0),
+        ]:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    self.parser._parse_decimal(value, self.mock_mapping_none_comma),
+                    expected,
+                )
 
     def test_int_inputs(self):
         # Sheet backends hand over native ints for whole values. Parsing them

--- a/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
@@ -398,6 +398,38 @@ class AccountStatementImportSheetParser(models.TransientModel):
         return [transaction]
 
     @api.model
+    def _check_decimal_mark(self, value, thousands, decimal):
+        """Refuse a value whose decimal mark the mapping does not account for.
+
+        A thousands separator always groups three digits, so a "." or a "," that
+        is followed by fewer than three digits at the end of the value can only
+        be a decimal mark. When it is not the configured one it gets stripped as
+        noise, which multiplies the amount by ten or a hundred -- silently, and
+        with no way to tell afterwards, since the factor varies per value.
+
+        Skipped when no decimal separator is configured: that mode reads the
+        last digits as the decimals, so it has a contract of its own.
+        """
+        if not decimal:
+            return
+        cleaned = re.sub(r"[^\d\-+.,]+", "", value)
+        for candidate in (".", ","):
+            if candidate in (thousands, decimal):
+                continue
+            if re.search(re.escape(candidate) + r"\d{1,2}$", cleaned):
+                raise UserError(
+                    self.env._(
+                        "Cannot read the amount %(value)s: it uses %(candidate)s as "
+                        "the decimal mark, but the statement mapping declares "
+                        "%(decimal)s. Importing it would change the amount. Fix the "
+                        "decimal separator of the mapping and import the file again.",
+                        value=value,
+                        candidate=candidate,
+                        decimal=decimal,
+                    )
+                )
+
+    @api.model
     def _parse_decimal(self, value, mapping):
         if isinstance(value, Decimal):
             return float(value)
@@ -406,6 +438,7 @@ class AccountStatementImportSheetParser(models.TransientModel):
             # whole values); they carry no separators to interpret.
             return float(value)
         thousands, decimal = mapping._get_float_separators()
+        self._check_decimal_mark(value, thousands, decimal)
         # Remove all characters except digits, thousands separator,
         # decimal separator, and signs
         value = (

--- a/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file/wizard/account_statement_import_sheet_parser.py
@@ -401,8 +401,10 @@ class AccountStatementImportSheetParser(models.TransientModel):
     def _parse_decimal(self, value, mapping):
         if isinstance(value, Decimal):
             return float(value)
-        elif isinstance(value, float):
-            return value
+        elif isinstance(value, int | float) and not isinstance(value, bool):
+            # Sheet backends hand over native numbers (openpyxl returns int for
+            # whole values); they carry no separators to interpret.
+            return float(value)
         thousands, decimal = mapping._get_float_separators()
         # Remove all characters except digits, thousands separator,
         # decimal separator, and signs

--- a/account_statement_import_sheet_file_xlsx/tests/test_account_statement_import_sheet_file_xlsx.py
+++ b/account_statement_import_sheet_file_xlsx/tests/test_account_statement_import_sheet_file_xlsx.py
@@ -4,7 +4,12 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from base64 import b64encode
+from datetime import datetime
+from io import BytesIO
 from os import path
+
+import openpyxl
 
 from odoo.exceptions import UserError
 from odoo.tools import mute_logger
@@ -26,6 +31,62 @@ class TestAccountStatementImportSheetFileXlsx(
         statement = self.AccountBankStatement.search(self.statement_domain)
         self.assertEqual(len(statement), 1)
         self.assertEqual(len(statement.line_ids), 2)
+
+    def test_import_xlsx_numeric_amounts_with_comma_decimal_sep(self):
+        """Numeric cells must not be reinterpreted through the mapping seps.
+
+        Amounts stored as numbers carry no separators: the sheet only holds a
+        display format, which never reaches the parser. Rendering them as text
+        printed a dot decimal, so a mapping set to a comma decimal separator
+        dropped it and shifted the amount by a factor of 10 or 100 depending on
+        how many decimals the value had.
+        """
+        self.sample_statement_map.write(
+            {
+                "float_thousands_sep": "none",
+                "float_decimal_sep": "comma",
+                "original_currency_column": None,
+                "original_amount_column": None,
+                "partner_name_column": None,
+                "bank_account_column": None,
+                "reference_column": "Reference",
+            }
+        )
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        sheet.append(["Date", "Label", "Reference", "Amount"])
+        # Amounts as native numbers, with a display format that shows a comma
+        # decimal separator -- exactly what the mapping is configured for. The
+        # reference is numeric too, to cover a non-amount column that stops
+        # being handed over as text.
+        for label, reference, amount in [
+            ("TWO DECIMALS", 26182, 1234.56),
+            ("ONE DECIMAL", 289400, 78.9),
+            ("NO DECIMALS", 304102, 100),
+        ]:
+            sheet.append([datetime(2026, 7, 1), label, reference, amount])
+            sheet.cell(row=sheet.max_row, column=4).number_format = "#.##0,00"
+        buffer = BytesIO()
+        workbook.save(buffer)
+        wizard = self.AccountStatementImport.with_context(
+            journal_id=self.journal.id, account_statement_import_sheet_file_test=True
+        ).create(
+            {
+                "statement_filename": "numeric_amounts.xlsx",
+                "statement_file": b64encode(buffer.getvalue()),
+                "sheet_mapping_id": self.sample_statement_map.id,
+            }
+        )
+        wizard.import_file_button()
+        statement = self.AccountBankStatement.search(self.statement_domain)
+        self.assertEqual(len(statement), 1)
+        self.assertEqual(len(statement.line_ids), 3)
+        self.assertEqual(
+            sorted(statement.line_ids.mapped("amount")), [78.9, 100.0, 1234.56]
+        )
+        self.assertEqual(
+            sorted(statement.line_ids.mapped("ref")), ["26182", "289400", "304102"]
+        )
 
     def test_import_empty_xlsx_file(self):
         wizard = self._get_import_wizard("fixtures/empty_statement_en.xlsx")

--- a/account_statement_import_sheet_file_xlsx/wizard/account_statement_import_sheet_parser.py
+++ b/account_statement_import_sheet_file_xlsx/wizard/account_statement_import_sheet_parser.py
@@ -82,6 +82,13 @@ class AccountStatementImportSheetParser(models.TransientModel):
                 cell_value = xlsx.cell(row=row, column=col_index).value
                 if isinstance(cell_value, datetime):
                     cell_value = cell_value.strftime(mapping.timestamp_format)
-                values.append(str(cell_value))
+                elif isinstance(cell_value, bool) or not isinstance(
+                    cell_value, int | float
+                ):
+                    # Keep numbers native: stringifying them here would render
+                    # the decimal point with Python notation, which no longer
+                    # matches the separators configured in the mapping.
+                    cell_value = str(cell_value)
+                values.append(cell_value)
             parsed_rows.append(values)
         return parsed_rows


### PR DESCRIPTION
## Depends on #996

This branch is stacked on #996, so the diff below shows **two** commits. Only
the second one (`[IMP] ... refuse an unconfigured decimal mark`) belongs to this
PR. Opened as a draft until #996 lands — the diff resolves itself once it does.

## Problem

#996 stops the xlsx backend from rendering numbers as text, so numeric cells no
longer get a decimal mark invented for them. What it cannot address is a value
that is genuinely text in the sheet: `31.24` under a mapping that declares a
comma decimal separator still has its dot stripped as noise, and the amount
silently becomes `3124`. The factor varies per value, so the imported statement
cannot be corrected afterwards — it has to be re-imported.

## Rule

A thousands separator always groups three digits. So a `.` or a `,` followed by
fewer than three digits at the end of a value cannot be a thousands group: it is
a decimal mark. When it is not the one the mapping declares, the value cannot be
read under that mapping, and the import refuses it.

This is a check, not a guess. It does not try to infer what the user meant and
it leaves every ambiguous case alone: `1.234`, `1.234.567` and `100.000` keep
being read exactly as the mapping says.

Skipped when the mapping declares no decimal separator: that mode reads the last
digits as the decimals, so it has a contract of its own.

## Tests

- `test_decimal_mark_not_in_mapping` — `31.24`, `-41.94`, `460763013.7` and
  `31.24 USD` are refused under a comma decimal separator.
- `test_decimal_mark_thousands_group_is_allowed` — well-formed thousands groups
  and correctly configured values keep working.

Full suite of the three `sheet_file` modules: 29 passed, including the existing
xlsx fixtures that use a comma decimal separator.

## Note for reviewers

This turns imports that today finish "successfully" into errors. Every one of
them was producing wrong amounts, but it is a behaviour change and deserves its
own discussion — which is why it is not part of #996.
