### PR TITLE
[19.0][FIX] account_statement_import_qif: Parse Australian DMY dates

### DIFF
--- a/account_statement_import_qif/README.rst
+++ b/account_statement_import_qif/README.rst
@@ -103,6 +103,8 @@ Contributors
 
   - Pedro M. Baeza
 
+- Ryan Duguid (https://github.com/ryanduguid)
+
 Maintainers
 -----------
 

--- a/account_statement_import_qif/__manifest__.py
+++ b/account_statement_import_qif/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Import QIF Bank Statements",
     "category": "Accounting",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "OpenERP SA,Tecnativa,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/bank-statement-import",
     "depends": ["account_statement_import_file"],

--- a/account_statement_import_qif/readme/CONTRIBUTORS.md
+++ b/account_statement_import_qif/readme/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
   - Ronald Portier \<rportier@therp.nl\>
 - Tecnativa (<https://www.tecnativa.com>)
   - Pedro M. Baeza
+- Ryan Duguid (<https://github.com/ryanduguid>)

--- a/account_statement_import_qif/static/description/index.html
+++ b/account_statement_import_qif/static/description/index.html
@@ -445,6 +445,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 </ul>
 </li>
+<li>Ryan Duguid (<a class="reference external" href="https://github.com/ryanduguid">https://github.com/ryanduguid</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_statement_import_qif/tests/test_import_bank_statement.py
+++ b/account_statement_import_qif/tests/test_import_bank_statement.py
@@ -3,9 +3,11 @@
 # Copyright 2015 Ronald Portier <rportier@therp.nl>
 # Copyright 2016-2017 Tecnativa - Pedro M. Baeza
 # Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2026 Ryan Duguid
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
+from datetime import date
 
 from odoo.tests.common import TransactionCase
 from odoo.tools.misc import file_path
@@ -53,3 +55,62 @@ class TestQifFile(TransactionCase):
             limit=1,
         )
         self.assertEqual(line.partner_id, self.partner)
+
+    def _parse_qif_transactions(self, qif_bytes):
+        wizard = self.statement_import_model.with_context(
+            journal_id=self.journal.id
+        ).create(
+            {
+                "statement_file": base64.b64encode(qif_bytes),
+                "statement_filename": "test.qif",
+            }
+        )
+        _currency, _account, stmts = wizard._parse_file(qif_bytes)
+        return stmts[0]["transactions"]
+
+    def test_qif_us_mdy_dates_from_unambiguous_day(self):
+        """Keep US month-first dates when the file has a day > 12."""
+        qif_file_path = file_path("account_statement_import_qif/tests/test_qif.qif")
+        with open(qif_file_path, "rb") as qif_file:
+            transactions = self._parse_qif_transactions(qif_file.read())
+        self.assertEqual(transactions[0]["date"], date(2013, 8, 12))
+        self.assertEqual(transactions[1]["date"], date(2013, 8, 15))
+
+    def test_qif_australian_dmy_dates_from_unambiguous_day(self):
+        """Respect dd/mm/yyyy when a day > 12 makes the order unambiguous.
+
+        Regression for https://github.com/OCA/bank-statement-import/issues/982
+        """
+        qif = (
+            b"!Type:Bank\n"
+            b"D31/07/2026\n"
+            b"T60.00\n"
+            b"PTransaction 1\n"
+            b"^\n"
+            b"D08/07/2026\n"
+            b"T360.00\n"
+            b"PTransaction 2\n"
+            b"^\n"
+            b"D01/07/2026\n"
+            b"T0.00\n"
+            b"PTransaction 3\n"
+            b"^\n"
+        )
+        self.env.company.country_id = self.env.ref("base.us")
+        transactions = self._parse_qif_transactions(qif)
+        self.assertEqual(
+            [line["date"] for line in transactions],
+            [date(2026, 7, 31), date(2026, 7, 8), date(2026, 7, 1)],
+        )
+
+    def test_qif_ambiguous_dates_follow_company_country(self):
+        qif = (
+            b"!Type:Bank\nD08/07/2026\nT10.00\nPOne\n^\nD01/06/2026\nT20.00\nPTwo\n^\n"
+        )
+        self.env.company.country_id = self.env.ref("base.us")
+        us_dates = [line["date"] for line in self._parse_qif_transactions(qif)]
+        self.assertEqual(us_dates, [date(2026, 8, 7), date(2026, 1, 6)])
+
+        self.env.company.country_id = self.env.ref("base.au")
+        au_dates = [line["date"] for line in self._parse_qif_transactions(qif)]
+        self.assertEqual(au_dates, [date(2026, 7, 8), date(2026, 6, 1)])

--- a/account_statement_import_qif/wizards/account_statement_import_qif.py
+++ b/account_statement_import_qif/wizards/account_statement_import_qif.py
@@ -2,14 +2,19 @@
 # Copyright 2015 Laurent Mignon <laurent.mignon@acsone.eu>
 # Copyright 2015 Ronald Portier <rportier@therp.nl>
 # Copyright 2016-2017 Tecnativa - Pedro M. Baeza
+# Copyright 2026 Ryan Duguid
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
+import re
 
 import dateutil.parser
 
 from odoo import api, models
 from odoo.exceptions import UserError
+
+# Numeric QIF dates in these countries use day/month/year.
+_QIF_DMY_COUNTRY_CODES = frozenset({"AU", "NZ", "GB", "IE", "ZA", "IN"})
 
 
 class AccountStatementImport(models.TransientModel):
@@ -18,6 +23,51 @@ class AccountStatementImport(models.TransientModel):
     @api.model
     def _check_qif(self, data_file):
         return data_file.strip().startswith(b"!Type:")
+
+    def _qif_detect_dayfirst_from_dates(self, date_strings):
+        """Return True/False when dates in the file have an unambiguous order.
+
+        QIF does not declare locale. ``08/07/2026`` is 8 July in Australia and
+        7 August in the US. A day or month number above 12 tells us which.
+        Year-first ISO values (first part > 31) are skipped; dateutil already
+        parses those independently of ``dayfirst``.
+        """
+        saw_dmy = False
+        saw_mdy = False
+        for raw in date_strings:
+            parts = [int(part) for part in re.findall(r"\d+", raw)]
+            if len(parts) < 2:
+                continue
+            first, second = parts[0], parts[1]
+            if first > 31:
+                continue
+            if first > 12:
+                saw_dmy = True
+            if 12 < second <= 31:
+                saw_mdy = True
+        if saw_dmy and not saw_mdy:
+            return True
+        if saw_mdy and not saw_dmy:
+            return False
+        return None
+
+    def _qif_lang_dayfirst(self):
+        lang_code = self.env.user.lang or self.env.company.partner_id.lang
+        if not lang_code:
+            return False
+        lang = self.env["res.lang"].search([("code", "=", lang_code)], limit=1)
+        date_format = lang.date_format or ""
+        day_pos = date_format.find("%d")
+        month_pos = date_format.find("%m")
+        return day_pos != -1 and month_pos != -1 and day_pos < month_pos
+
+    def _qif_dayfirst(self, date_strings):
+        detected = self._qif_detect_dayfirst_from_dates(date_strings)
+        if detected is not None:
+            return detected
+        if self._qif_lang_dayfirst():
+            return True
+        return self.env.company.country_id.code in _QIF_DMY_COUNTRY_CODES
 
     def _parse_file(self, data_file):
         if not self._check_qif(data_file):
@@ -37,13 +87,17 @@ class AccountStatementImport(models.TransientModel):
         total = 0
         if header in ("Bank", "CCard"):
             vals_bank_statement = {}
+            date_strings = [
+                line.strip()[1:] for line in data_list if line.strip()[:1] == "D"
+            ]
+            dayfirst = self._qif_dayfirst(date_strings)
             for line in data_list:
                 line = line.strip()
                 if not line:
                     continue
                 if line[0] == "D":  # date of transaction
                     vals_line["date"] = dateutil.parser.parse(
-                        line[1:], fuzzy=True
+                        line[1:], fuzzy=True, dayfirst=dayfirst
                     ).date()
                 elif line[0] == "T":  # Total amount
                     total += float(line[1:].replace(",", ""))


### PR DESCRIPTION
Fixes #982

## Summary

- detect day/month order from unambiguous QIF dates (a day or month number above 12)
- fall back to the user language date format, then to day-first company countries (`AU`, `NZ`, `GB`, `IE`, `ZA`, `IN`)
- keep US month-first files working, including the existing `8/15/13` fixture

`dateutil.parser.parse()` defaults to month-first. In the report, `D31/07/2026` parsed as 31 July (month 31 is invalid) while `D08/07/2026` and `D01/07/2026` flipped to 7 August and 7 January.

## Verification

- `pre-commit run --files account_statement_import_qif/wizards/account_statement_import_qif.py account_statement_import_qif/tests/test_import_bank_statement.py account_statement_import_qif/__manifest__.py account_statement_import_qif/readme/CONTRIBUTORS.md account_statement_import_qif/README.rst` (passes)
- GitHub CI and Runboat remain the integration checks for `oca_run_tests`

## Ownership
I reviewed, understand, and take responsibility for every line in this contribution.