### PR TITLE
[19.0][FIX] account_statement_import_qif: parse Australian dd/mm dates

### DIFF
--- a/account_statement_import_qif/qif_dates.py
+++ b/account_statement_import_qif/qif_dates.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Ryan Duguid <ryan@duguid.com.au>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import re
+
+# Numeric dates in these countries are written day-first (dd/mm/yyyy).
+# Used only when the QIF file itself does not prove a format.
+QIF_DAYFIRST_COUNTRIES = frozenset(
+    {
+        "AU",
+        "NZ",
+        "GB",
+        "IE",
+        "ZA",
+        "IN",
+        "DE",
+        "FR",
+        "ES",
+        "IT",
+        "NL",
+        "BE",
+        "PT",
+        "AT",
+        "CH",
+        "SE",
+        "NO",
+        "DK",
+        "FI",
+        "PL",
+        "BR",
+    }
+)
+
+_QIF_DATE_SPLIT = re.compile(r"[/\-.]")
+
+
+def qif_numeric_date_parts(raw):
+    """Return integer date parts from a QIF date field, or an empty tuple."""
+    parts = []
+    for token in _QIF_DATE_SPLIT.split((raw or "").strip()):
+        digits = "".join(char for char in token if char.isdigit())
+        if digits:
+            parts.append(int(digits))
+    return tuple(parts)
+
+
+def qif_file_dayfirst(date_strings):
+    """Return True/False when the file proves dd/mm or mm/dd, else None.
+
+    A first component above 12 is a day (31/07/2026). A second component
+    above 12 is a month-first date (8/15/13). Year-first ISO dates are
+    ignored. dateutil still parses each line independently, so a mixed
+    file of 31/07/2026 and 08/07/2026 is otherwise imported as 31 July
+    and 7 August.
+    """
+    saw_day_first = False
+    saw_month_first = False
+    for raw in date_strings:
+        parts = qif_numeric_date_parts(raw)
+        if len(parts) < 2:
+            continue
+        first, second = parts[0], parts[1]
+        if first > 31:
+            # 2026-07-31 — year first, not a day/month order signal
+            continue
+        if first > 12:
+            saw_day_first = True
+        elif 12 < second <= 31:
+            saw_month_first = True
+    if saw_day_first and not saw_month_first:
+        return True
+    if saw_month_first and not saw_day_first:
+        return False
+    return None

--- a/account_statement_import_qif/tests/test_import_bank_statement.py
+++ b/account_statement_import_qif/tests/test_import_bank_statement.py
@@ -3,12 +3,16 @@
 # Copyright 2015 Ronald Portier <rportier@therp.nl>
 # Copyright 2016-2017 Tecnativa - Pedro M. Baeza
 # Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2026 Ryan Duguid <ryan@duguid.com.au>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
+from datetime import date
 
 from odoo.tests.common import TransactionCase
 from odoo.tools.misc import file_path
+
+from odoo.addons.account_statement_import_qif.qif_dates import qif_file_dayfirst
 
 
 class TestQifFile(TransactionCase):
@@ -36,9 +40,20 @@ class TestQifFile(TransactionCase):
             }
         )
 
+    def _parse_qif(self, data, journal=None):
+        journal = journal or self.journal
+        wizard = self.statement_import_model.with_context(journal_id=journal.id).create(
+            {
+                "statement_file": base64.b64encode(data),
+                "statement_filename": "test.qif",
+            }
+        )
+        return wizard._parse_file(data)
+
     def test_qif_file_import(self):
         qif_file_path = file_path("account_statement_import_qif/tests/test_qif.qif")
-        qif_file = base64.b64encode(open(qif_file_path, "rb").read())
+        with open(qif_file_path, "rb") as qif_stream:
+            qif_file = base64.b64encode(qif_stream.read())
         wizard = self.statement_import_model.with_context(
             journal_id=self.journal.id
         ).create({"statement_file": qif_file, "statement_filename": "test_qif.qif"})
@@ -53,3 +68,47 @@ class TestQifFile(TransactionCase):
             limit=1,
         )
         self.assertEqual(line.partner_id, self.partner)
+        self.assertEqual(line.date, date(2013, 3, 3))
+
+    def test_qif_file_dayfirst_detection(self):
+        self.assertTrue(qif_file_dayfirst(["31/07/2026", "08/07/2026", "01/07/2026"]))
+        self.assertFalse(qif_file_dayfirst(["8/12/13", "8/15/13", "3/3/13"]))
+        self.assertIsNone(qif_file_dayfirst(["08/07/2026", "01/07/2026"]))
+        self.assertIsNone(qif_file_dayfirst(["2026-07-31"]))
+
+    def test_qif_australian_dates_from_file(self):
+        """A day > 12 in the file proves dd/mm for the whole statement.
+
+        Without a file-level hint, dateutil parses 08/07/2026 as 7 August
+        and 01/07/2026 as 7 January, which is the #982 Australian QIF bug.
+        """
+        qif_file_path = file_path("account_statement_import_qif/tests/test_qif_au.qif")
+        with open(qif_file_path, "rb") as qif_file:
+            _currency, _account, stmts = self._parse_qif(qif_file.read())
+        dates = [line["date"] for line in stmts[0]["transactions"]]
+        self.assertEqual(
+            dates,
+            [date(2026, 7, 31), date(2026, 7, 8), date(2026, 7, 1)],
+        )
+
+    def test_qif_australian_ambiguous_dates_use_company_country(self):
+        self.env.company.country_id = self.env.ref("base.au")
+        data = (
+            b"!Type:Bank\n"
+            b"D08/07/2026\nT360.00\nPTransaction 2\n^\n"
+            b"D01/07/2026\nT0.00\nPTransaction 3\n^\n"
+        )
+        _currency, _account, stmts = self._parse_qif(data)
+        dates = [line["date"] for line in stmts[0]["transactions"]]
+        self.assertEqual(dates, [date(2026, 7, 8), date(2026, 7, 1)])
+
+    def test_qif_us_ambiguous_dates_stay_month_first(self):
+        self.env.company.country_id = self.env.ref("base.us")
+        data = (
+            b"!Type:Bank\n"
+            b"D08/07/2026\nT360.00\nPTransaction 2\n^\n"
+            b"D01/07/2026\nT0.00\nPTransaction 3\n^\n"
+        )
+        _currency, _account, stmts = self._parse_qif(data)
+        dates = [line["date"] for line in stmts[0]["transactions"]]
+        self.assertEqual(dates, [date(2026, 8, 7), date(2026, 1, 7)])

--- a/account_statement_import_qif/tests/test_import_bank_statement.py
+++ b/account_statement_import_qif/tests/test_import_bank_statement.py
@@ -112,3 +112,15 @@ class TestQifFile(TransactionCase):
         _currency, _account, stmts = self._parse_qif(data)
         dates = [line["date"] for line in stmts[0]["transactions"]]
         self.assertEqual(dates, [date(2026, 8, 7), date(2026, 1, 7)])
+
+    def test_qif_iso_dates_keep_year_month_day_order(self):
+        self.env.company.country_id = self.env.ref("base.au")
+        for prefix in (b"", b"D31/07/2026\nT10.00\nPDay-first transaction\n^\n"):
+            with self.subTest(prefix=prefix):
+                data = (
+                    b"!Type:Bank\n"
+                    + prefix
+                    + b"D2026-07-08\nT360.00\nPISO transaction\n^\n"
+                )
+                _currency, _account, stmts = self._parse_qif(data)
+                self.assertEqual(stmts[0]["transactions"][-1]["date"], date(2026, 7, 8))

--- a/account_statement_import_qif/tests/test_qif_au.qif
+++ b/account_statement_import_qif/tests/test_qif_au.qif
@@ -1,0 +1,16 @@
+!Type:Bank
+D31/07/2026
+T60.00
+PTransaction 1
+LDEP
+^
+D08/07/2026
+T360.00
+PTransaction 2
+LDEP
+^
+D01/07/2026
+T0.00
+PTransaction 3
+LJDR
+^

--- a/account_statement_import_qif/wizards/account_statement_import_qif.py
+++ b/account_statement_import_qif/wizards/account_statement_import_qif.py
@@ -2,6 +2,7 @@
 # Copyright 2015 Laurent Mignon <laurent.mignon@acsone.eu>
 # Copyright 2015 Ronald Portier <rportier@therp.nl>
 # Copyright 2016-2017 Tecnativa - Pedro M. Baeza
+# Copyright 2026 Ryan Duguid <ryan@duguid.com.au>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
@@ -11,6 +12,8 @@ import dateutil.parser
 from odoo import api, models
 from odoo.exceptions import UserError
 
+from ..qif_dates import QIF_DAYFIRST_COUNTRIES, qif_file_dayfirst
+
 
 class AccountStatementImport(models.TransientModel):
     _inherit = "account.statement.import"
@@ -18,6 +21,36 @@ class AccountStatementImport(models.TransientModel):
     @api.model
     def _check_qif(self, data_file):
         return data_file.strip().startswith(b"!Type:")
+
+    def _qif_locale_dayfirst(self):
+        """Whether the company locale writes numeric dates day-first.
+
+        Company country is the accounting localisation. The user language
+        is only a fallback: an Australian company with an en_US user still
+        receives Australian bank files as dd/mm/yyyy.
+        """
+        journal = self.env["account.journal"].browse(self.env.context.get("journal_id"))
+        company = journal.company_id if journal else self.env.company
+        if company.country_id.code in QIF_DAYFIRST_COUNTRIES:
+            return True
+        lang_code = self.env.user.lang or company.partner_id.lang
+        if lang_code:
+            lang = self.env["res.lang"].search([("code", "=", lang_code)], limit=1)
+            if lang and lang.date_format:
+                day_pos = lang.date_format.find("%d")
+                month_pos = lang.date_format.find("%m")
+                if day_pos != -1 and month_pos != -1:
+                    return day_pos < month_pos
+        return False
+
+    def _qif_dayfirst(self, date_strings):
+        file_hint = qif_file_dayfirst(date_strings)
+        if file_hint is not None:
+            return file_hint
+        return self._qif_locale_dayfirst()
+
+    def _qif_parse_date(self, raw, dayfirst):
+        return dateutil.parser.parse(raw, fuzzy=True, dayfirst=dayfirst).date()
 
     def _parse_file(self, data_file):
         if not self._check_qif(data_file):
@@ -37,14 +70,16 @@ class AccountStatementImport(models.TransientModel):
         total = 0
         if header in ("Bank", "CCard"):
             vals_bank_statement = {}
+            date_strings = [
+                line.strip()[1:] for line in data_list if line.strip()[:1] == "D"
+            ]
+            dayfirst = self._qif_dayfirst(date_strings)
             for line in data_list:
                 line = line.strip()
                 if not line:
                     continue
                 if line[0] == "D":  # date of transaction
-                    vals_line["date"] = dateutil.parser.parse(
-                        line[1:], fuzzy=True
-                    ).date()
+                    vals_line["date"] = self._qif_parse_date(line[1:], dayfirst)
                 elif line[0] == "T":  # Total amount
                     total += float(line[1:].replace(",", ""))
                     vals_line["amount"] = float(line[1:].replace(",", ""))

--- a/account_statement_import_qif/wizards/account_statement_import_qif.py
+++ b/account_statement_import_qif/wizards/account_statement_import_qif.py
@@ -12,7 +12,11 @@ import dateutil.parser
 from odoo import api, models
 from odoo.exceptions import UserError
 
-from ..qif_dates import QIF_DAYFIRST_COUNTRIES, qif_file_dayfirst
+from ..qif_dates import (
+    QIF_DAYFIRST_COUNTRIES,
+    qif_file_dayfirst,
+    qif_numeric_date_parts,
+)
 
 
 class AccountStatementImport(models.TransientModel):
@@ -50,6 +54,9 @@ class AccountStatementImport(models.TransientModel):
         return self._qif_locale_dayfirst()
 
     def _qif_parse_date(self, raw, dayfirst):
+        parts = qif_numeric_date_parts(raw)
+        if parts and parts[0] > 31:
+            dayfirst = False
         return dateutil.parser.parse(raw, fuzzy=True, dayfirst=dayfirst).date()
 
     def _parse_file(self, data_file):


### PR DESCRIPTION
Fixes #982.

Uses unambiguous dates in a QIF file to select day-first or month-first parsing. If the file supplies no usable preference, the importer uses the company country, then the user language with a company-language fallback. Australian `08/07/2026` therefore imports as 8 July, while the existing US fixture keeps its month-first interpretation.

Explicit year-first dates retain year/month/day order even in a day-first file or locale. Regression coverage includes an ISO-only Australian file and a mixed ISO/day-first file.

Verification, 10 September 2026:

- Six local cases passed against the actual parser method, including ISO, slash-separated and compact year-first dates, Australian dates and US dates.
- The repository's pre-commit checks passed on both changed files. Pylint reports existing unknown-option warnings in the shared configuration.
- Odoo TransactionCase coverage was added. Odoo and OCB integration tests run in upstream CI; neither Docker nor WSL is installed on the local Windows host.

No live bank data was used. This update used AI assistance; the verification above uses fabricated inputs.
