### PR TITLE
[19.0][FIX] account_statement_import_online: fix flaky midnight-UTC test

### DIFF
--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -103,14 +103,10 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
     def test_pull_scheduled(self):
         self.provider.next_run = self.now - relativedelta(days=15)
         self._getExpectedStatements(0)
-        # _adjust_schedule() reads datetime.now(), not cls.now. Hold it at
-        # the pinned noon so a 00:00-00:59 UTC run does not cross midnight.
-        with mock.patch(
-            "odoo.addons.account_statement_import_online.models"
-            ".online_bank_statement_provider.datetime.now",
-            return_value=self.now,
-        ):
-            self.provider.with_context(step={"hours": 8})._scheduled_pull()
+        # next_run stays noon-aligned. _adjust_schedule() uses wall-clock
+        # datetime.now(), but a :00 slot never makes the 1-hour pull window
+        # cross midnight into a second daily statement.
+        self.provider.with_context(step={"hours": 8})._scheduled_pull()
         self._getExpectedStatements(1)
 
     def test_pull_skip_duplicates_by_unique_import_id(self):

--- a/account_statement_import_online/tests/test_account_bank_statement_import_online.py
+++ b/account_statement_import_online/tests/test_account_bank_statement_import_online.py
@@ -40,7 +40,9 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
         )
 
         cls.env.user.tz = "UTC"
-        cls.now = fields.Datetime.now()
+        # Noon UTC so now-1h stays on the same calendar day. CI near midnight
+        # otherwise opens two daily statement periods (18.0: #918).
+        cls.now = fields.Datetime.now().replace(hour=12, minute=0, second=0)
         cls.AccountAccount = cls.env["account.account"]
         cls.AccountJournal = cls.env["account.journal"]
         cls.OnlineBankStatementProvider = cls.env["online.bank.statement.provider"]
@@ -101,7 +103,14 @@ class TestAccountBankAccountStatementImportOnline(common.TransactionCase):
     def test_pull_scheduled(self):
         self.provider.next_run = self.now - relativedelta(days=15)
         self._getExpectedStatements(0)
-        self.provider.with_context(step={"hours": 8})._scheduled_pull()
+        # _adjust_schedule() reads datetime.now(), not cls.now. Hold it at
+        # the pinned noon so a 00:00-00:59 UTC run does not cross midnight.
+        with mock.patch(
+            "odoo.addons.account_statement_import_online.models"
+            ".online_bank_statement_provider.datetime.now",
+            return_value=self.now,
+        ):
+            self.provider.with_context(step={"hours": 8})._scheduled_pull()
         self._getExpectedStatements(1)
 
     def test_pull_skip_duplicates_by_unique_import_id(self):


### PR DESCRIPTION
Forward-port of #918 to 19.0.

## Summary

- pin `cls.now` to noon UTC so `now - 1 hour` stays on one calendar day

## Problem

`test_wizard` and `test_wizard_on_journal` fail when CI runs between 00:00 and 00:59 UTC:

```
AssertionError: 2 != 1
Names and dates for statements found: BANK/2026-08-28 - 2026-08-28, BANK/2026-08-29 - 2026-08-29
```

Daily statement mode opens a period per calendar day. A one-hour window that crosses midnight becomes two statements. Seen on #999 and #1000 (00:25–00:29 UTC on 2026-08-29). 19.0 itself is green when tests run later in the day.

#918 already pins `cls.now` on 18.0. That is enough here too. `test_pull_scheduled` keeps a noon-aligned `next_run`, so the 1-hour window `_adjust_schedule()` builds from wall-clock `datetime.now()` never spans two calendar days.

An earlier attempt to `mock.patch` `datetime.now` failed on CPython (`TypeError: cannot set 'now' attribute of immutable type 'datetime.datetime'`). That mock is not needed and is not used.

## Verification

- Isolated check that `mock.patch` of `datetime.now` raises the CI TypeError
- Hour-by-hour simulation of `_adjust_schedule` + daily statement split with noon-aligned `next_run` (0 failing hours)
- GitHub CI and Runboat remain the integration checks for `oca_run_tests`

## Ownership
I reviewed, understand, and take responsibility for every line in this contribution.