### PR TITLE
[19.0][FIX] account_statement_import_base: match IBANs that contain spaces

### DIFF
--- a/account_statement_import_base/models/account_journal.py
+++ b/account_statement_import_base/models/account_journal.py
@@ -1,5 +1,6 @@
 # Copyright 2022 Akretion France (http://www.akretion.com/)
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# Copyright 2026 Ryan Duguid <ryan@duguid.com.au>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import api, models
@@ -24,7 +25,10 @@ class AccountJournal(models.Model):
             ["acc_number", "partner_id"],
         )
         for partner_bank in partner_banks:
-            speeddict["account_number"][partner_bank["acc_number"]] = {
+            acc_number = self._sanitize_bank_account_number(partner_bank["acc_number"])
+            if not acc_number:
+                continue
+            speeddict["account_number"][acc_number] = {
                 "partner_id": partner_bank["partner_id"][0],
                 "partner_bank_id": partner_bank["id"],
             }

--- a/account_statement_import_base/tests/__init__.py
+++ b/account_statement_import_base/tests/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import test_account_journal

--- a/account_statement_import_base/tests/test_account_journal.py
+++ b/account_statement_import_base/tests/test_account_journal.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Ryan Duguid <ryan@duguid.com.au>
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestAccountJournalImport(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "IBAN Vendor"})
+        cls.partner_bank = cls.env["res.partner.bank"].create(
+            {
+                "partner_id": cls.partner.id,
+                "acc_number": "DE07 3105 0000 0000 1431 56",
+                "company_id": cls.env.company.id,
+            }
+        )
+        cls.journal = cls.env["account.journal"].create(
+            {
+                "name": "IBAN Bank",
+                "code": "IBAN",
+                "type": "bank",
+            }
+        )
+
+    def test_speeddict_keys_are_sanitized(self):
+        speeddict = self.journal._statement_line_import_speeddict()
+        self.assertNotIn(
+            "DE07 3105 0000 0000 1431 56",
+            speeddict["account_number"],
+        )
+        self.assertEqual(
+            speeddict["account_number"]["DE07310500000000143156"],
+            {
+                "partner_id": self.partner.id,
+                "partner_bank_id": self.partner_bank.id,
+            },
+        )
+
+    def test_partner_match_iban_with_spaces(self):
+        """Lookup after sanitizing the imported IBAN must find the partner.
+
+        CAMT files store IBANs without spaces. res.partner.bank often
+        stores the same number with grouping spaces. The speeddict used
+        to key on the raw acc_number, so the sanitized lookup missed.
+        """
+        speeddict = self.journal._statement_line_import_speeddict()
+        vals = {"account_number": "DE07310500000000143156"}
+        self.journal._statement_line_import_update_hook(vals, speeddict)
+        self.assertEqual(vals["partner_id"], self.partner.id)
+        self.assertEqual(vals["partner_bank_id"], self.partner_bank.id)
+
+    def test_partner_match_iban_from_spaced_import(self):
+        speeddict = self.journal._statement_line_import_speeddict()
+        vals = {"account_number": "DE07 3105 0000 0000 1431 56"}
+        self.journal._statement_line_import_update_hook(vals, speeddict)
+        self.assertEqual(vals["account_number"], "DE07310500000000143156")
+        self.assertEqual(vals["partner_id"], self.partner.id)
+        self.assertEqual(vals["partner_bank_id"], self.partner_bank.id)


### PR DESCRIPTION
Fixes #929

## Summary

- `_statement_line_import_update_hook` sanitizes the imported account number before lookup
- `_statement_line_import_speeddict` keyed the cache on the raw `res.partner.bank` `acc_number`
- a partner bank stored as `DE07 3105 0000 0000 1431 56` therefore missed a CAMT line with `DE07310500000000143156`
- sanitize the cache keys with the same `_sanitize_bank_account_number` hook used on import

## Verification

- added TransactionCase coverage for a spaced IBAN on the partner bank and both spaced and compact imported account numbers
- `python3 -m ruff check --config .ruff.toml` on the touched files (ruff 0.13.0)
- GitHub CI and Runboat remain the integration checks for `oca_run_tests`

## AI assistance

I reviewed, understand, and take responsibility for every line in this contribution.