### PR TITLE
[18.0][FIX] account_statement_import_camt: fill payment_ref with  AddtlNtryInf

### DIFF
--- a/account_statement_import_camt/models/account_statement_import_camt_parser.py
+++ b/account_statement_import_camt/models/account_statement_import_camt_parser.py
@@ -302,6 +302,17 @@ class AccountStatementImportCamtParser(models.AbstractModel):
             transaction["narration"],
             f"{_('Additional Entry Information')} (AddtlNtryInf)",
         )
+        # Some formats (like Wise.com) put the transaction description in a
+        # Ntry-level `AddtlNtryInf` node, outside any `TxDtls`. Use it as a
+        # fallback `payment_ref` if parse_transaction_details (which runs
+        # later on the TxDtls node) does not find a more precise one.
+        addtl_infos = node.xpath("./ns:AddtlNtryInf", namespaces={"ns": ns})
+        if addtl_infos and transaction.get("payment_ref") == "/":
+            addtl_info = "\n".join(
+                x.text.strip() for x in addtl_infos if x.text and x.text.strip()
+            )
+            if addtl_info:
+                transaction["payment_ref"] = addtl_info
         self.add_value_from_node(
             ns,
             node,

--- a/account_statement_import_camt/tests/samples/golden-camt053-no-txdtls.pydata
+++ b/account_statement_import_camt/tests/samples/golden-camt053-no-txdtls.pydata
@@ -1,0 +1,50 @@
+('EUR',
+ 'BE00000000000000',
+ [{'balance_end_real': 100.0,
+   'balance_start': 0.0,
+   'date': '2026-06-28T21:40:58.810767+02:00',
+   'name': '52995589-87806609-1783466312332',
+   'transactions': [{'amount': -900.0,
+                     'date': '2026-06-28T21:40:58.810767+02:00',
+                     'narration': 'Partner Name (RltdPties/Nm): \n'
+                                  'Partner Account Number (RltdPties/Acct): \n'
+                                  'Transaction Date (BookgDt): 2026-06-28T21:40:58.810767+02:00\n'
+                                  'Reference: \n'
+                                  'Communication: \n'
+                                  'Transaction Type (BkTxCd): \n'
+                                  'Additional Entry Information (AddtlNtryInf): Card transaction of 900.00 EUR issued by Provider',
+                     'payment_ref': 'Card transaction of 900.00 EUR issued by Provider',
+                     'transaction_type': ''},
+                    {'amount': -232.0,
+                     'date': '2026-06-05T10:00:00+02:00',
+                     'narration': 'Partner Name (RltdPties/Nm): John Doe\n'
+                                  'Partner Account Number (RltdPties/Acct): \n'
+                                  'Transaction Date (BookgDt): 2026-06-05T10:00:00+02:00\n'
+                                  'Reference: \n'
+                                  'Communication: \n'
+                                  'Transaction Type (BkTxCd): \n'
+                                  'Additional Entry Information (AddtlNtryInf): Sent money to John Doe',
+                     'partner_name': 'John Doe',
+                     'payment_ref': 'Sent money to John Doe',
+                     'transaction_type': ''},
+                    {'amount': 1000.0,
+                     'date': '2026-06-03T09:52:08.054666+02:00',
+                     'narration': 'Partner Name (RltdPties/Nm): \n'
+                                  'Partner Account Number (RltdPties/Acct): \n'
+                                  'Transaction Date (BookgDt): 2026-06-03T09:52:08.054666+02:00\n'
+                                  'Reference: \n'
+                                  'Communication: \n'
+                                  'Transaction Type (BkTxCd): ',
+                     'payment_ref': '/',
+                     'transaction_type': ''},
+                    {'amount': 25.0,
+                     'date': '2026-06-10T08:00:00+02:00',
+                     'narration': 'Partner Name (RltdPties/Nm): \n'
+                                  'Partner Account Number (RltdPties/Acct): \n'
+                                  'Transaction Date (BookgDt): 2026-06-10T08:00:00+02:00\n'
+                                  'Reference: \n'
+                                  'Communication: \n'
+                                  'Transaction Type (BkTxCd): \n'
+                                  'Additional Entry Information (AddtlNtryInf):    ',
+                     'payment_ref': '/',
+                     'transaction_type': ''}]}])

--- a/account_statement_import_camt/tests/samples/golden-camt053-txdtls.pydata
+++ b/account_statement_import_camt/tests/samples/golden-camt053-txdtls.pydata
@@ -20,7 +20,7 @@
                                   'Account Servicer Reference (Refs/AcctSvcrRef): 123456CHCAFEBABE\n'
                                   'Postal Address (PstlAdr): Place Saint-François | 14 | 1003 | Lausanne | CH1',
                      'partner_name': 'Banque Cantonale Vaudoise',
-                     'payment_ref': '/',
+                     'payment_ref': 'CRÉDIT GROUPÉ BVR TRAITEMENT DU 22.03.2017 NUMÉRO CLIENT 01-70884-3 PAQUET ID: 123456CHCAFEBABE',
                      'ref': '302388292000011111111111111',
                      'transaction_type': 'PMNT-RCDT-VCOM'},
                     {'account_number': 'CH3333000000123456789',
@@ -39,6 +39,6 @@
                                   'Account Servicer Reference (Refs/AcctSvcrRef): 123456CHCAFEBABE\n'
                                   'Postal Address (PstlAdr): Place Saint-François | 14 | 1003 | Lausanne | CH2',
                      'partner_name': 'Banque Cantonale Vaudoise',
-                     'payment_ref': '/',
+                     'payment_ref': 'CRÉDIT GROUPÉ BVR TRAITEMENT DU 22.03.2017 NUMÉRO CLIENT 01-70884-3 PAQUET ID: 123456CHCAFEBABE',
                      'ref': '302388292000022222222222222',
                      'transaction_type': 'PMNT-RCDT-VCOM'}]}])

--- a/account_statement_import_camt/tests/samples/test-camt053-no-txdtls
+++ b/account_statement_import_camt/tests/samples/test-camt053-no-txdtls
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.10">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>52995589-1783466312332</MsgId>
+            <CreDtTm>2026-07-07T23:18:32.332104506Z</CreDtTm>
+        </GrpHdr>
+        <Stmt>
+            <Id>52995589-87806609-1783466312332</Id>
+            <CreDtTm>2026-07-07T23:18:32.332104506Z</CreDtTm>
+            <FrToDt>
+                <FrDtTm>2026-06-01T00:00:00+02:00</FrDtTm>
+                <ToDtTm>2026-07-01T00:00:00+02:00</ToDtTm>
+            </FrToDt>
+            <Acct>
+                <Id>
+                    <IBAN>BE00000000000000</IBAN>
+                </Id>
+                <Ccy>EUR</Ccy>
+                <Ownr>
+                    <Nm>ACME Corporation</Nm>
+                    <PstlAdr>
+                        <AdrTp>
+                            <Cd>ADDR</Cd>
+                        </AdrTp>
+                        <PstCd>12345</PstCd>
+                        <TwnNm>Springfield</TwnNm>
+                        <AdrLine>Fake Str. 123</AdrLine>
+                    </PstlAdr>
+                    <Id>
+                        <OrgId>
+                            <Othr>
+                                <Id>B12345678</Id>
+                                <SchmeNm>
+                                    <Cd>COID</Cd>
+                                </SchmeNm>
+                            </Othr>
+                        </OrgId>
+                    </Id>
+                </Ownr>
+                <Svcr>
+                    <FinInstnId>
+                        <Nm>Wise Europe SA</Nm>
+                        <PstlAdr>
+                            <AdrTp>
+                                <Cd>ADDR</Cd>
+                            </AdrTp>
+                            <PstCd>1050</PstCd>
+                            <TwnNm>Brussels</TwnNm>
+                            <AdrLine>Rue du Trône 100, 3rd floor</AdrLine>
+                        </PstlAdr>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">100.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <DtTm>2026-07-01T00:00:00+02:00</DtTm>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="EUR">0.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <DtTm>2026-06-01T00:00:00+02:00</DtTm>
+                </Dt>
+            </Bal>
+            <TxsSummry>
+                <TtlNtries>
+                    <NbOfNtries>4</NbOfNtries>
+                    <Sum>-107.00</Sum>
+                    <TtlNetNtry>
+                        <Amt>-107.00</Amt>
+                        <CdtDbtInd>DBIT</CdtDbtInd>
+                    </TtlNetNtry>
+                </TtlNtries>
+                <TtlCdtNtries>
+                    <NbOfNtries>2</NbOfNtries>
+                    <Sum>1025.00</Sum>
+                </TtlCdtNtries>
+                <TtlDbtNtries>
+                    <NbOfNtries>2</NbOfNtries>
+                    <Sum>-1132.00</Sum>
+                </TtlDbtNtries>
+            </TxsSummry>
+            <Ntry>
+                <Amt Ccy="EUR">900.00</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Sts>
+                    <Cd>BOOK</Cd>
+                </Sts>
+                <BookgDt>
+                    <DtTm>2026-06-28T21:40:58.810767+02:00</DtTm>
+                </BookgDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>CARD-0123456789</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <AddtlNtryInf>Card transaction of 900.00 EUR issued by Provider</AddtlNtryInf>
+            </Ntry>
+            <Ntry>
+                <NtryRef>compras</NtryRef>
+                <Amt Ccy="EUR">232.00</Amt>
+                <CdtDbtInd>DBIT</CdtDbtInd>
+                <Sts>
+                    <Cd>BOOK</Cd>
+                </Sts>
+                <BookgDt>
+                    <DtTm>2026-06-05T10:00:00+02:00</DtTm>
+                </BookgDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>TRANSFER-9876543210</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <NtryDtls>
+                    <TxDtls>
+                        <RltdPties>
+                            <Cdtr>
+                                <Pty>
+                                    <Nm>John Doe</Nm>
+                                </Pty>
+                            </Cdtr>
+                        </RltdPties>
+                    </TxDtls>
+                </NtryDtls>
+                <AddtlNtryInf>Sent money to John Doe</AddtlNtryInf>
+            </Ntry>
+            <Ntry>
+                <Amt Ccy="EUR">1000.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>
+                    <Cd>BOOK</Cd>
+                </Sts>
+                <BookgDt>
+                    <DtTm>2026-06-03T09:52:08.054666+02:00</DtTm>
+                </BookgDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>14f0b58de0089edb1ef85f57ffc5052d</Cd>
+                    </Prtry>
+                </BkTxCd>
+            </Ntry>
+            <Ntry>
+                <Amt Ccy="EUR">25.00</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Sts>
+                    <Cd>BOOK</Cd>
+                </Sts>
+                <BookgDt>
+                    <DtTm>2026-06-10T08:00:00+02:00</DtTm>
+                </BookgDt>
+                <BkTxCd>
+                    <Prtry>
+                        <Cd>REIMBURSEMENT-1234567890</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <AddtlNtryInf>   </AddtlNtryInf>
+            </Ntry>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>

--- a/account_statement_import_camt/tests/test_import_bank_statement.py
+++ b/account_statement_import_camt/tests/test_import_bank_statement.py
@@ -95,6 +95,9 @@ class TestParser(TestParserCommon):
     def test_parse_no_ntry(self):
         self._do_parse_test("test-camt053-no-ntry", "golden-camt053-no-ntry.pydata")
 
+    def test_parse_no_txdtls(self):
+        self._do_parse_test("test-camt053-no-txdtls", "golden-camt053-no-txdtls.pydata")
+
 
 class TestImport(TransactionCase):
     """Run test to import camt import."""


### PR DESCRIPTION
Some formats (like Wise.com) put the transaction description in a Ntry-level `AddtlNtryInf` node, outside any `TxDtls`.

Use it as a fallback `payment_ref` if _parse_transaction_details_ (which runs later on the TxDtls node) does not find a more precise one.

Replace #974 :
In #974 the Ntry-level `AddtlNtryInf` node is used to fill `payment_ref` only if there is not TxDtls node (`len(details_nodes) == 0`), but in the Wise.com statements the transfer statements do have a TxDtls node even if the transaction description is still in the Ntry-level `AddtlNtryInf` node. (cf the improved account_statement_import_camt/tests/samples/test-camt053-no-txdtls)