### PR TITLE
[19.0][FIX] account_statement_import_online: pull each provider in its own company

### DIFF
--- a/account_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_statement_import_online/models/online_bank_statement_provider.py
@@ -196,6 +196,7 @@ class OnlineBankStatementProvider(models.Model):
         debug = self.env.context.get("account_statement_online_import_debug")
         debug_data = []
         for provider in self:
+            provider = provider.with_company(provider.company_id)
             statement_date_since = provider._get_statement_date_since(date_since)
             while statement_date_since < date_until:
                 # Note that statement_date_until is exclusive, while date_until is


### PR DESCRIPTION
`_pull` ran in the caller's current company (the cron user's, or the wizard user's), so company-dependent values read during import resolved in the wrong company for providers of another company. Scope each provider to its journal's company inside `_pull`, which covers the cron and the manual wizard alike.